### PR TITLE
Add multi-image post support with upload progress and carousels

### DIFF
--- a/yummr/CreatePostView.swift
+++ b/yummr/CreatePostView.swift
@@ -6,8 +6,10 @@ import PhotosUI
 struct CreatePostView: View {
     @State private var title = ""
     @State private var description = ""
-    @State private var selectedImage: UIImage?
-    @State private var selectedPhoto: PhotosPickerItem?
+    @State private var selectedImages: [UIImage] = []
+    @State private var selectedPhotos: [PhotosPickerItem] = []
+    @State private var uploadProgress: [Double] = []
+    @State private var editMode: EditMode = .inactive
     @State private var isUploading = false
     @State private var uploadSuccess = false
     @State private var errorMessage: String?
@@ -22,50 +24,71 @@ struct CreatePostView: View {
                     .textFieldStyle(RoundedBorderTextFieldStyle())
 
                 PhotosPicker(
-                    selection: $selectedPhoto,
+                    selection: $selectedPhotos,
+                    maxSelectionCount: 5,
                     matching: .images,
                     photoLibrary: .shared()
                 ) {
-                    if let image = selectedImage {
-                        Image(uiImage: image)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(height: 200)
-                            .cornerRadius(10)
-                    } else {
-                        Text("Select an Image")
-                            .foregroundColor(.blue)
-                    }
+                    Text("Select Images")
+                        .foregroundColor(.blue)
                 }
-                .onChange(of: selectedPhoto) {
+                .onChange(of: selectedPhotos) { items in
                     Task {
-                        if let data = try? await selectedPhoto?.loadTransferable(type: Data.self),
-                           let uiImage = UIImage(data: data) {
-                            selectedImage = uiImage
+                        selectedImages = []
+                        for item in items {
+                            if let data = try? await item.loadTransferable(type: Data.self),
+                               let uiImage = UIImage(data: data) {
+                                selectedImages.append(uiImage)
+                            }
                         }
                     }
                 }
 
-
-                if isUploading {
-                    ProgressView("Uploading...")
+                if !selectedImages.isEmpty {
+                    List {
+                        ForEach(selectedImages.indices, id: \.self) { index in
+                            VStack {
+                                Image(uiImage: selectedImages[index])
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(height: 200)
+                                    .cornerRadius(10)
+                                if isUploading && uploadProgress.indices.contains(index) {
+                                    ProgressView(value: uploadProgress[index])
+                                }
+                            }
+                        }
+                        .onMove { indices, newOffset in
+                            selectedImages.move(fromOffsets: indices, toOffset: newOffset)
+                        }
+                    }
+                    .frame(height: 250)
+                    .environment(\.editMode, $editMode)
                 }
 
                 Button("Post") {
-                    guard let image = selectedImage else {
-                        errorMessage = "Please select an image."
+                    guard !selectedImages.isEmpty else {
+                        errorMessage = "Please select at least one image."
                         return
                     }
 
                     isUploading = true
-                    PostService.shared.uploadPost(title: title, description: description, image: image) { result in
+                    uploadProgress = Array(repeating: 0, count: selectedImages.count)
+                    PostService.shared.uploadPost(title: title, description: description, images: selectedImages, progressHandler: { index, progress in
+                        DispatchQueue.main.async {
+                            if uploadProgress.indices.contains(index) {
+                                uploadProgress[index] = progress
+                            }
+                        }
+                    }) { result in
                         isUploading = false
                         switch result {
                         case .success:
                             uploadSuccess = true
                             title = ""
                             description = ""
-                            selectedImage = nil
+                            selectedImages = []
+                            selectedPhotos = []
                         case .failure(let error):
                             errorMessage = error.localizedDescription
                         }
@@ -90,6 +113,7 @@ struct CreatePostView: View {
             }
             .padding()
             .navigationTitle("Create Post")
+            .toolbar { EditButton() }
         }
     }
 }

--- a/yummr/Post.swift
+++ b/yummr/Post.swift
@@ -10,18 +10,18 @@ struct Post: Identifiable, Codable {
     @DocumentID var id: String?
     var title: String
     var description: String
-    var imageURL: String
+    var imageURLs: [String]
     var timestamp: Date
     var authorID: String
     var authorName: String
     var likedBy: [String]
     var likeCount: Int
 //push
-    init(id: String? = nil, title: String, description: String, imageURL: String, timestamp: Date, authorID: String, authorName: String, likedBy: [String] = [], likeCount: Int = 0) {
+    init(id: String? = nil, title: String, description: String, imageURLs: [String], timestamp: Date, authorID: String, authorName: String, likedBy: [String] = [], likeCount: Int = 0) {
         self.id = id
         self.title = title
         self.description = description
-        self.imageURL = imageURL
+        self.imageURLs = imageURLs
         self.timestamp = timestamp
         self.authorID = authorID
         self.authorName = authorName

--- a/yummr/PostCard.swift
+++ b/yummr/PostCard.swift
@@ -1,9 +1,6 @@
 import SwiftUI
 import FirebaseAuth
 import FirebaseFirestore
-import SwiftUI
-import FirebaseAuth
-import FirebaseFirestore
 //push
 
 struct PostCard: View {
@@ -30,21 +27,27 @@ struct PostCard: View {
                 .font(.subheadline)
                 .foregroundColor(.gray)
 
-            AsyncImage(url: URL(string: post.imageURL)) { phase in
-                switch phase {
-                case .empty:
-                    ProgressView()
-                case .success(let image):
-                    image
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .cornerRadius(12)
-                case .failure:
-                    Image(systemName: "photo")
-                @unknown default:
-                    EmptyView()
+            TabView {
+                ForEach(post.imageURLs, id: \.self) { urlString in
+                    AsyncImage(url: URL(string: urlString)) { phase in
+                        switch phase {
+                        case .empty:
+                            ProgressView()
+                        case .success(let image):
+                            image
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .cornerRadius(12)
+                        case .failure:
+                            Image(systemName: "photo")
+                        @unknown default:
+                            EmptyView()
+                        }
+                    }
                 }
             }
+            .frame(height: 300)
+            .tabViewStyle(PageTabViewStyle())
 
             Text(post.description)
                 .font(.body)

--- a/yummr/PostDetailView.swift
+++ b/yummr/PostDetailView.swift
@@ -17,16 +17,22 @@ struct PostDetailView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            AsyncImage(url: URL(string: post.imageURL)) { phase in
-                switch phase {
-                case .success(let image):
-                    image
-                        .resizable()
-                        .scaledToFit()
-                default:
-                    Color.gray.frame(height: 200)
+            TabView {
+                ForEach(post.imageURLs, id: \.self) { urlString in
+                    AsyncImage(url: URL(string: urlString)) { phase in
+                        switch phase {
+                        case .success(let image):
+                            image
+                                .resizable()
+                                .scaledToFit()
+                        default:
+                            Color.gray.frame(height: 200)
+                        }
+                    }
                 }
             }
+            .frame(height: 300)
+            .tabViewStyle(PageTabViewStyle())
 
             Text(post.title)
                 .font(.title2)

--- a/yummr/ProfileView.swift
+++ b/yummr/ProfileView.swift
@@ -74,7 +74,7 @@ struct ProfileView: View {
                 LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
                     ForEach(userPosts) { post in
                         VStack {
-                            AsyncImage(url: URL(string: post.imageURL)) { phase in
+                            AsyncImage(url: URL(string: post.imageURLs.first ?? "")) { phase in
                                 switch phase {
                                 case .empty:
                                     ProgressView()


### PR DESCRIPTION
## Summary
- Store multiple image URLs per post
- Allow selecting and reordering multiple images with upload progress
- Display swipeable image carousels in post card and detail views

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b400294883239bb16b07b959640c