### PR TITLE
Add navigation to user posts feed

### DIFF
--- a/yummr.xcodeproj/project.pbxproj
+++ b/yummr.xcodeproj/project.pbxproj
@@ -21,7 +21,8 @@
 		D03E44002E12C0F600FE91E9 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03E43FF2E12C0F600FE91E9 /* ProfileView.swift */; };
 		D03E44042E12DE2B00FE91E9 /* PostDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03E44032E12DE2B00FE91E9 /* PostDetailView.swift */; };
 		D03E44062E12DE3800FE91E9 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03E44052E12DE3800FE91E9 /* Comment.swift */; };
-		D03E44082E12DFE800FE91E9 /* AllCommentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03E44072E12DFE800FE91E9 /* AllCommentsView.swift */; };
+                D03E44082E12DFE800FE91E9 /* AllCommentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03E44072E12DFE800FE91E9 /* AllCommentsView.swift */; };
+                D0F2222A2E70000100691496 /* UserPostsFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0F222292E70000100691496 /* UserPostsFeedView.swift */; };
 		D0DDE65D2E0FD0BA00691496 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE65C2E0FD0BA00691496 /* Post.swift */; };
 		D0DDE65F2E0FD0CB00691496 /* FeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE65E2E0FD0CB00691496 /* FeedView.swift */; };
 		D0DDE6612E0FDBB100691496 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE6602E0FDBB100691496 /* KeychainHelper.swift */; };
@@ -46,7 +47,8 @@
 		D03E43FF2E12C0F600FE91E9 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		D03E44032E12DE2B00FE91E9 /* PostDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailView.swift; sourceTree = "<group>"; };
 		D03E44052E12DE3800FE91E9 /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
-		D03E44072E12DFE800FE91E9 /* AllCommentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllCommentsView.swift; sourceTree = "<group>"; };
+                D03E44072E12DFE800FE91E9 /* AllCommentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllCommentsView.swift; sourceTree = "<group>"; };
+                D0F222292E70000100691496 /* UserPostsFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPostsFeedView.swift; sourceTree = "<group>"; };
 		D0DDE65C2E0FD0BA00691496 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		D0DDE65E2E0FD0CB00691496 /* FeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedView.swift; sourceTree = "<group>"; };
 		D0DDE6602E0FDBB100691496 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
@@ -97,9 +99,10 @@
 				D0E7494C2E377245008B42CD /* notes.swift */,
 				D03E44072E12DFE800FE91E9 /* AllCommentsView.swift */,
 				D03E44052E12DE3800FE91E9 /* Comment.swift */,
-				D03E44032E12DE2B00FE91E9 /* PostDetailView.swift */,
-				D03E43FF2E12C0F600FE91E9 /* ProfileView.swift */,
-				D0DDE6762E100F4500691496 /* ImagePicker.swift */,
+                                D03E44032E12DE2B00FE91E9 /* PostDetailView.swift */,
+                                D03E43FF2E12C0F600FE91E9 /* ProfileView.swift */,
+                                D0F222292E70000100691496 /* UserPostsFeedView.swift */,
+                                D0DDE6762E100F4500691496 /* ImagePicker.swift */,
 				D0DDE66C2E10084100691496 /* CreatePostView.swift */,
 				D0DDE66A2E10080900691496 /* PostService.swift */,
 				D0DDE6662E10079800691496 /* StorageService.swift */,
@@ -227,11 +230,12 @@
 				D0DDE6672E10079900691496 /* StorageService.swift in Sources */,
 				D0DDE6612E0FDBB100691496 /* KeychainHelper.swift in Sources */,
 				D0DDE66D2E10084100691496 /* CreatePostView.swift in Sources */,
-				D03E44062E12DE3800FE91E9 /* Comment.swift in Sources */,
-				D0DDE65F2E0FD0CB00691496 /* FeedView.swift in Sources */,
-				D0DDE6632E0FDD7A00691496 /* LoginView.swift in Sources */,
-				D03E44002E12C0F600FE91E9 /* ProfileView.swift in Sources */,
-				D0DDE65D2E0FD0BA00691496 /* Post.swift in Sources */,
+                            D03E44062E12DE3800FE91E9 /* Comment.swift in Sources */,
+                            D0DDE65F2E0FD0CB00691496 /* FeedView.swift in Sources */,
+                            D0DDE6632E0FDD7A00691496 /* LoginView.swift in Sources */,
+                            D03E44002E12C0F600FE91E9 /* ProfileView.swift in Sources */,
+                            D0F2222A2E70000100691496 /* UserPostsFeedView.swift in Sources */,
+                            D0DDE65D2E0FD0BA00691496 /* Post.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/yummr/ProfileView.swift
+++ b/yummr/ProfileView.swift
@@ -17,96 +17,102 @@ struct ProfileView: View {
     private let db = Firestore.firestore()
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .center, spacing: 16) {
-                // Profile Picture
-                ZStack(alignment: .bottomTrailing) {
-                    if let url = profileImageURL {
-                        AsyncImage(url: url) { image in
-                            image.resizable()
-                        } placeholder: {
-                            ProgressView()
-                        }
-                        .frame(width: 100, height: 100)
-                        .clipShape(Circle())
-                    } else {
-                        Circle()
-                            .fill(Color.gray)
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .center, spacing: 16) {
+                    // Profile Picture
+                    ZStack(alignment: .bottomTrailing) {
+                        if let url = profileImageURL {
+                            AsyncImage(url: url) { image in
+                                image.resizable()
+                            } placeholder: {
+                                ProgressView()
+                            }
                             .frame(width: 100, height: 100)
+                            .clipShape(Circle())
+                        } else {
+                            Circle()
+                                .fill(Color.gray)
+                                .frame(width: 100, height: 100)
+                        }
+
+                        Button(action: {
+                            showImagePicker = true
+                        }) {
+                            Image(systemName: "pencil.circle.fill")
+                                .foregroundColor(.blue)
+                        }
+                        .offset(x: 5, y: 5)
                     }
 
-                    Button(action: {
-                        showImagePicker = true
-                    }) {
-                        Image(systemName: "pencil.circle.fill")
-                            .foregroundColor(.blue)
+                    // Name and Bio
+                    Text(auth.currentUser?.displayName ?? auth.currentUser?.email ?? "Username")
+                        .font(.title2)
+                        .bold()
+
+                    if isEditing {
+                        TextField("Enter bio", text: $bio)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .padding(.horizontal)
+                        Button("Save") {
+                            updateBio()
+                            isEditing = false
+                        }
+                    } else {
+                        Text(bio.isEmpty ? "No bio yet." : bio)
+                            .italic()
+                            .foregroundColor(.gray)
+                        Button("Edit Bio") {
+                            isEditing = true
+                        }
                     }
-                    .offset(x: 5, y: 5)
-                }
 
-                // Name and Bio
-                Text(auth.currentUser?.displayName ?? auth.currentUser?.email ?? "Username")
-                    .font(.title2)
-                    .bold()
+                    // User's Posts Grid
+                    Text("My Posts")
+                        .font(.headline)
+                        .padding(.top)
 
-                if isEditing {
-                    TextField("Enter bio", text: $bio)
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
-                        .padding(.horizontal)
-                    Button("Save") {
-                        updateBio()
-                        isEditing = false
-                    }
-                } else {
-                    Text(bio.isEmpty ? "No bio yet." : bio)
-                        .italic()
-                        .foregroundColor(.gray)
-                    Button("Edit Bio") {
-                        isEditing = true
-                    }
-                }
-
-                // User's Posts Grid
-                Text("My Posts")
-                    .font(.headline)
-                    .padding(.top)
-
-                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
-                    ForEach(userPosts) { post in
-                        VStack {
-                            AsyncImage(url: URL(string: post.imageURL)) { phase in
-                                switch phase {
-                                case .empty:
-                                    ProgressView()
-                                case .success(let image):
-                                    image.resizable()
-                                        .aspectRatio(contentMode: .fill)
-                                        .frame(height: 100)
-                                        .clipped()
-                                        .cornerRadius(8)
-                                case .failure:
-                                    Image(systemName: "photo")
-                                @unknown default:
-                                    EmptyView()
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
+                        ForEach(userPosts) { post in
+                            NavigationLink {
+                                UserPostsFeedView(authorID: post.authorID, authorName: post.authorName)
+                            } label: {
+                                VStack {
+                                    AsyncImage(url: URL(string: post.imageURL)) { phase in
+                                        switch phase {
+                                        case .empty:
+                                            ProgressView()
+                                        case .success(let image):
+                                            image.resizable()
+                                                .aspectRatio(contentMode: .fill)
+                                                .frame(height: 100)
+                                                .clipped()
+                                                .cornerRadius(8)
+                                        case .failure:
+                                            Image(systemName: "photo")
+                                        @unknown default:
+                                            EmptyView()
+                                        }
+                                    }
+                                    Text(post.title)
+                                        .font(.caption)
+                                        .lineLimit(1)
                                 }
                             }
-                            Text(post.title)
-                                .font(.caption)
-                                .lineLimit(1)
+                            .buttonStyle(.plain)
                         }
                     }
                 }
-
+                .padding()
             }
-            .padding()
-        }
-        .navigationTitle("Profile")
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {
-                    showSettings = true
-                }) {
-                    Image(systemName: "gear")
+            .navigationTitle("Profile")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        showSettings = true
+                    }) {
+                        Image(systemName: "gear")
+                    }
                 }
             }
         }

--- a/yummr/UserPostsFeedView.swift
+++ b/yummr/UserPostsFeedView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import FirebaseFirestore
+
+struct UserPostsFeedView: View {
+    let authorID: String
+    var authorName: String?
+
+    @State private var posts: [Post] = []
+    @State private var isLoading = true
+
+    private let db = Firestore.firestore()
+
+    private var navigationTitle: String {
+        if let name = authorName, !name.isEmpty {
+            if name.lowercased().hasSuffix("s") {
+                return "\(name)' Posts"
+            } else {
+                return "\(name)'s Posts"
+            }
+        } else {
+            return "User Posts"
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            if isLoading {
+                ProgressView("Loading posts...")
+                    .padding()
+            } else if posts.isEmpty {
+                Text("No posts to show yet.")
+                    .foregroundColor(.secondary)
+                    .padding()
+            } else {
+                LazyVStack(spacing: 24) {
+                    ForEach(posts) { post in
+                        PostCard(post: post)
+                    }
+                }
+                .padding(.vertical)
+            }
+        }
+        .padding(.horizontal)
+        .navigationTitle(navigationTitle)
+        .onAppear {
+            fetchPosts()
+        }
+    }
+
+    private func fetchPosts() {
+        isLoading = true
+
+        db.collection("posts")
+            .whereField("authorID", isEqualTo: authorID)
+            .order(by: "timestamp", descending: true)
+            .getDocuments { snapshot, error in
+                self.isLoading = false
+
+                if let error = error {
+                    print("Failed to fetch user posts: \(error)")
+                    self.posts = []
+                    return
+                }
+
+                guard let documents = snapshot?.documents else {
+                    self.posts = []
+                    return
+                }
+
+                self.posts = documents.compactMap { try? $0.data(as: Post.self) }
+            }
+    }
+}


### PR DESCRIPTION
## Summary
- wrap the profile tab content in a NavigationView and link each grid item to a reusable author feed
- add UserPostsFeedView to query Firestore for a user's posts and render them with PostCard

## Testing
- not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68c882164ff48323b3c11113eca97748