### PR TITLE
Add user posts feed view and navigation from profile

### DIFF
--- a/yummr.xcodeproj/project.pbxproj
+++ b/yummr.xcodeproj/project.pbxproj
@@ -21,8 +21,9 @@
 		D03E44002E12C0F600FE91E9 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03E43FF2E12C0F600FE91E9 /* ProfileView.swift */; };
 		D03E44042E12DE2B00FE91E9 /* PostDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03E44032E12DE2B00FE91E9 /* PostDetailView.swift */; };
 		D03E44062E12DE3800FE91E9 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03E44052E12DE3800FE91E9 /* Comment.swift */; };
-		D03E44082E12DFE800FE91E9 /* AllCommentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03E44072E12DFE800FE91E9 /* AllCommentsView.swift */; };
-		D0DDE65D2E0FD0BA00691496 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE65C2E0FD0BA00691496 /* Post.swift */; };
+                D03E44082E12DFE800FE91E9 /* AllCommentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03E44072E12DFE800FE91E9 /* AllCommentsView.swift */; };
+                20EE8CD89FDC41D0A46F8425 /* UserPostsFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACFE0121D6E54FB8907793A3 /* UserPostsFeedView.swift */; };
+                D0DDE65D2E0FD0BA00691496 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE65C2E0FD0BA00691496 /* Post.swift */; };
 		D0DDE65F2E0FD0CB00691496 /* FeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE65E2E0FD0CB00691496 /* FeedView.swift */; };
 		D0DDE6612E0FDBB100691496 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE6602E0FDBB100691496 /* KeychainHelper.swift */; };
 		D0DDE6632E0FDD7A00691496 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE6622E0FDD7A00691496 /* LoginView.swift */; };
@@ -46,8 +47,9 @@
 		D03E43FF2E12C0F600FE91E9 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		D03E44032E12DE2B00FE91E9 /* PostDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailView.swift; sourceTree = "<group>"; };
 		D03E44052E12DE3800FE91E9 /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
-		D03E44072E12DFE800FE91E9 /* AllCommentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllCommentsView.swift; sourceTree = "<group>"; };
-		D0DDE65C2E0FD0BA00691496 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
+                D03E44072E12DFE800FE91E9 /* AllCommentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllCommentsView.swift; sourceTree = "<group>"; };
+                ACFE0121D6E54FB8907793A3 /* UserPostsFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPostsFeedView.swift; sourceTree = "<group>"; };
+                D0DDE65C2E0FD0BA00691496 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		D0DDE65E2E0FD0CB00691496 /* FeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedView.swift; sourceTree = "<group>"; };
 		D0DDE6602E0FDBB100691496 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		D0DDE6622E0FDD7A00691496 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
@@ -97,9 +99,10 @@
 				D0E7494C2E377245008B42CD /* notes.swift */,
 				D03E44072E12DFE800FE91E9 /* AllCommentsView.swift */,
 				D03E44052E12DE3800FE91E9 /* Comment.swift */,
-				D03E44032E12DE2B00FE91E9 /* PostDetailView.swift */,
-				D03E43FF2E12C0F600FE91E9 /* ProfileView.swift */,
-				D0DDE6762E100F4500691496 /* ImagePicker.swift */,
+                                D03E44032E12DE2B00FE91E9 /* PostDetailView.swift */,
+                                D03E43FF2E12C0F600FE91E9 /* ProfileView.swift */,
+                                ACFE0121D6E54FB8907793A3 /* UserPostsFeedView.swift */,
+                                D0DDE6762E100F4500691496 /* ImagePicker.swift */,
 				D0DDE66C2E10084100691496 /* CreatePostView.swift */,
 				D0DDE66A2E10080900691496 /* PostService.swift */,
 				D0DDE6662E10079800691496 /* StorageService.swift */,
@@ -229,9 +232,10 @@
 				D0DDE66D2E10084100691496 /* CreatePostView.swift in Sources */,
 				D03E44062E12DE3800FE91E9 /* Comment.swift in Sources */,
 				D0DDE65F2E0FD0CB00691496 /* FeedView.swift in Sources */,
-				D0DDE6632E0FDD7A00691496 /* LoginView.swift in Sources */,
-				D03E44002E12C0F600FE91E9 /* ProfileView.swift in Sources */,
-				D0DDE65D2E0FD0BA00691496 /* Post.swift in Sources */,
+                                D0DDE6632E0FDD7A00691496 /* LoginView.swift in Sources */,
+                                D03E44002E12C0F600FE91E9 /* ProfileView.swift in Sources */,
+                                20EE8CD89FDC41D0A46F8425 /* UserPostsFeedView.swift in Sources */,
+                                D0DDE65D2E0FD0BA00691496 /* Post.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/yummr/ProfileView.swift
+++ b/yummr/ProfileView.swift
@@ -17,96 +17,103 @@ struct ProfileView: View {
     private let db = Firestore.firestore()
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .center, spacing: 16) {
-                // Profile Picture
-                ZStack(alignment: .bottomTrailing) {
-                    if let url = profileImageURL {
-                        AsyncImage(url: url) { image in
-                            image.resizable()
-                        } placeholder: {
-                            ProgressView()
-                        }
-                        .frame(width: 100, height: 100)
-                        .clipShape(Circle())
-                    } else {
-                        Circle()
-                            .fill(Color.gray)
-                            .frame(width: 100, height: 100)
-                    }
-
-                    Button(action: {
-                        showImagePicker = true
-                    }) {
-                        Image(systemName: "pencil.circle.fill")
-                            .foregroundColor(.blue)
-                    }
-                    .offset(x: 5, y: 5)
-                }
-
-                // Name and Bio
-                Text(auth.currentUser?.displayName ?? auth.currentUser?.email ?? "Username")
-                    .font(.title2)
-                    .bold()
-
-                if isEditing {
-                    TextField("Enter bio", text: $bio)
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
-                        .padding(.horizontal)
-                    Button("Save") {
-                        updateBio()
-                        isEditing = false
-                    }
-                } else {
-                    Text(bio.isEmpty ? "No bio yet." : bio)
-                        .italic()
-                        .foregroundColor(.gray)
-                    Button("Edit Bio") {
-                        isEditing = true
-                    }
-                }
-
-                // User's Posts Grid
-                Text("My Posts")
-                    .font(.headline)
-                    .padding(.top)
-
-                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
-                    ForEach(userPosts) { post in
-                        VStack {
-                            AsyncImage(url: URL(string: post.imageURLs.first ?? "")) { phase in
-                                switch phase {
-                                case .empty:
-                                    ProgressView()
-                                case .success(let image):
-                                    image.resizable()
-                                        .aspectRatio(contentMode: .fill)
-                                        .frame(height: 100)
-                                        .clipped()
-                                        .cornerRadius(8)
-                                case .failure:
-                                    Image(systemName: "photo")
-                                @unknown default:
-                                    EmptyView()
-                                }
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .center, spacing: 16) {
+                    // Profile Picture
+                    ZStack(alignment: .bottomTrailing) {
+                        if let url = profileImageURL {
+                            AsyncImage(url: url) { image in
+                                image.resizable()
+                            } placeholder: {
+                                ProgressView()
                             }
-                            Text(post.title)
-                                .font(.caption)
-                                .lineLimit(1)
+                            .frame(width: 100, height: 100)
+                            .clipShape(Circle())
+                        } else {
+                            Circle()
+                                .fill(Color.gray)
+                                .frame(width: 100, height: 100)
+                        }
+
+                        Button(action: {
+                            showImagePicker = true
+                        }) {
+                            Image(systemName: "pencil.circle.fill")
+                                .foregroundColor(.blue)
+                        }
+                        .offset(x: 5, y: 5)
+                    }
+
+                    // Name and Bio
+                    Text(auth.currentUser?.displayName ?? auth.currentUser?.email ?? "Username")
+                        .font(.title2)
+                        .bold()
+
+                    if isEditing {
+                        TextField("Enter bio", text: $bio)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .padding(.horizontal)
+                        Button("Save") {
+                            updateBio()
+                            isEditing = false
+                        }
+                    } else {
+                        Text(bio.isEmpty ? "No bio yet." : bio)
+                            .italic()
+                            .foregroundColor(.gray)
+                        Button("Edit Bio") {
+                            isEditing = true
+                        }
+                    }
+
+                    // User's Posts Grid
+                    Text("My Posts")
+                        .font(.headline)
+                        .padding(.top)
+
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
+                        ForEach(userPosts) { post in
+                            NavigationLink {
+                                UserPostsFeedView(authorID: post.authorID, authorName: post.authorName)
+                            } label: {
+                                VStack {
+                                    AsyncImage(url: URL(string: post.imageURLs.first ?? "")) { phase in
+                                        switch phase {
+                                        case .empty:
+                                            ProgressView()
+                                        case .success(let image):
+                                            image.resizable()
+                                                .aspectRatio(contentMode: .fill)
+                                                .frame(height: 100)
+                                                .clipped()
+                                                .cornerRadius(8)
+                                        case .failure:
+                                            Image(systemName: "photo")
+                                        @unknown default:
+                                            EmptyView()
+                                        }
+                                    }
+                                    Text(post.title)
+                                        .font(.caption)
+                                        .lineLimit(1)
+                                }
+                                .foregroundColor(.primary)
+                            }
+                            .buttonStyle(PlainButtonStyle())
                         }
                     }
                 }
-
+                .padding()
             }
-            .padding()
-        }
-        .navigationTitle("Profile")
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {
-                    showSettings = true
-                }) {
-                    Image(systemName: "gear")
+            .navigationTitle("Profile")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        showSettings = true
+                    }) {
+                        Image(systemName: "gear")
+                    }
                 }
             }
         }

--- a/yummr/UserPostsFeedView.swift
+++ b/yummr/UserPostsFeedView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+
+struct UserPostsFeedView: View {
+    let authorID: String
+    var authorName: String?
+
+    @State private var posts: [Post] = []
+    @State private var isLoading = true
+    @State private var listener: ListenerRegistration?
+
+    private let db = Firestore.firestore()
+
+    var body: some View {
+        ScrollView {
+            if isLoading {
+                ProgressView()
+                    .padding()
+            } else if posts.isEmpty {
+                Text("No posts yet.")
+                    .foregroundColor(.secondary)
+                    .padding()
+            } else {
+                LazyVStack(spacing: 24) {
+                    ForEach(posts) { post in
+                        PostCard(post: post)
+                    }
+                }
+                .padding()
+            }
+        }
+        .navigationTitle(title)
+        .onAppear {
+            startListeningForPosts()
+        }
+        .onDisappear {
+            listener?.remove()
+            listener = nil
+        }
+    }
+
+    private var title: String {
+        if let name = authorName?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+            return "\(name)'s Posts"
+        } else {
+            return "User Posts"
+        }
+    }
+
+    private func startListeningForPosts() {
+        listener?.remove()
+        isLoading = true
+
+        listener = db.collection("posts")
+            .whereField("authorID", isEqualTo: authorID)
+            .order(by: "timestamp", descending: true)
+            .addSnapshotListener { snapshot, error in
+                DispatchQueue.main.async {
+                    if let error = error {
+                        print("Error fetching user posts:", error)
+                        self.posts = []
+                        self.isLoading = false
+                        return
+                    }
+
+                    guard let documents = snapshot?.documents else {
+                        self.posts = []
+                        self.isLoading = false
+                        return
+                    }
+
+                    self.posts = documents.compactMap { try? $0.data(as: Post.self) }
+                    self.isLoading = false
+                }
+            }
+    }
+}


### PR DESCRIPTION
## Summary
- embed the profile screen content in a navigation view and make each post tile open a dedicated user feed view
- add a reusable `UserPostsFeedView` that streams posts by author and renders them with existing `PostCard`
- wire the new view into the project so it can be used for both the signed-in user and other profiles

## Testing
- xcodebuild -list *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c88c74bb3c8323873da63d3121be89