### PR TITLE
Add audio capture workflow to AI drafting

### DIFF
--- a/yummr/AIDraftWorkshopView.swift
+++ b/yummr/AIDraftWorkshopView.swift
@@ -6,9 +6,12 @@ struct AIDraftWorkshopView: View {
     @Binding var description: String
     @Binding var recipe: String
     @Binding var selectedImages: [UIImage]
+    @Binding var audioTranscript: String
 
     @State private var ideaPrompt: String = ""
     @State private var capturedIdeas: [String] = []
+
+    @StateObject private var audioRecorder = AudioRecorderService()
 
     private let promptPlaceholder = "Describe the meal, ingredients, or vibe you want the AI to build on..."
 
@@ -17,6 +20,7 @@ struct AIDraftWorkshopView: View {
             VStack(alignment: .leading, spacing: 24) {
                 header
                 promptSection
+                audioCaptureSection
                 if !capturedIdeas.isEmpty {
                     capturedIdeasSection
                 }
@@ -28,6 +32,13 @@ struct AIDraftWorkshopView: View {
         }
         .navigationTitle("AI Draft")
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            audioRecorder.requestPermissions()
+        }
+        .onReceive(audioRecorder.$transcript) { transcript in
+            guard !transcript.isEmpty else { return }
+            audioTranscript = transcript
+        }
     }
 
     private var header: some View {
@@ -39,6 +50,90 @@ struct AIDraftWorkshopView: View {
                 .font(.callout)
                 .foregroundColor(.secondary)
         }
+    }
+
+    private var audioCaptureSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Voice Capture")
+                .font(.headline)
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 16) {
+                    Button {
+                        if audioRecorder.isRecording {
+                            audioRecorder.stopRecording()
+                        } else {
+                            audioRecorder.startRecording()
+                        }
+                    } label: {
+                        Label(audioRecorder.isRecording ? "Stop Recording" : "Record Idea",
+                              systemImage: audioRecorder.isRecording ? "stop.circle.fill" : "mic.circle.fill")
+                            .font(.headline)
+                            .labelStyle(.titleAndIcon)
+                    }
+                    .buttonStyle(audioRecorder.isRecording ? .borderedProminent : .bordered)
+                    .tint(audioRecorder.isRecording ? .red : .accentColor)
+                    .disabled(!audioRecorder.hasMicrophonePermission || audioRecorder.speechAuthorizationStatus != .authorized)
+
+                    Text(formattedTime(audioRecorder.elapsedTime))
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundColor(audioRecorder.isRecording ? .primary : .secondary)
+                    Spacer()
+                    Text("Max 60s")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                if let errorMessage = audioRecorder.errorMessage {
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Transcript")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        if !audioTranscript.isEmpty {
+                            Button("Clear") {
+                                audioTranscript = ""
+                                audioRecorder.resetTranscript()
+                            }
+                            .font(.caption)
+                        }
+                    }
+                    ZStack(alignment: .topLeading) {
+                        if audioTranscript.isEmpty {
+                            Text("Tap record and describe your dish to see a transcript here.")
+                                .foregroundColor(.secondary)
+                                .padding(.top, 8)
+                                .padding(.horizontal, 8)
+                        }
+                        TextEditor(text: $audioTranscript)
+                            .frame(minHeight: 120)
+                            .padding(4)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                            )
+                    }
+                }
+                Text("Review and edit the transcript before sending it with your AI request.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding()
+            .background(Color(UIColor.secondarySystemBackground))
+            .cornerRadius(12)
+        }
+    }
+
+    private func formattedTime(_ interval: TimeInterval) -> String {
+        let totalSeconds = max(0, Int(interval))
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+        return String(format: "%01d:%02d", minutes, seconds)
     }
 
     private var promptSection: some View {
@@ -212,7 +307,8 @@ struct AIDraftWorkshopView_Previews: PreviewProvider {
                 title: .constant("Weekend Brunch Bowl"),
                 description: .constant("A cozy bowl stacked with roasted veggies and a bright herb sauce."),
                 recipe: .constant("1. Roast vegetables\n2. Toss with sauce"),
-                selectedImages: .constant([])
+                selectedImages: .constant([]),
+                audioTranscript: .constant("Toast bread. Layer greens. Finish with lemon zest.")
             )
         }
     }

--- a/yummr/AudioRecorderService.swift
+++ b/yummr/AudioRecorderService.swift
@@ -1,0 +1,248 @@
+import Foundation
+import AVFoundation
+import Speech
+
+class AudioRecorderService: NSObject, ObservableObject {
+    enum RecorderError: LocalizedError {
+        case microphonePermissionDenied
+        case speechPermissionDenied
+        case recognizerUnavailable
+        case unableToCreateRecorder
+        case unknown
+
+        var errorDescription: String? {
+            switch self {
+            case .microphonePermissionDenied:
+                return "Microphone access is denied. Enable it in Settings to record audio."
+            case .speechPermissionDenied:
+                return "Speech recognition access is denied. Enable it in Settings to transcribe audio."
+            case .recognizerUnavailable:
+                return "Speech recognizer is currently unavailable."
+            case .unableToCreateRecorder:
+                return "Unable to start audio recorder."
+            case .unknown:
+                return "An unexpected recording error occurred."
+            }
+        }
+    }
+
+    @Published private(set) var isRecording: Bool = false
+    @Published private(set) var elapsedTime: TimeInterval = 0
+    @Published private(set) var transcript: String = ""
+    @Published var errorMessage: String?
+    @Published private(set) var hasMicrophonePermission: Bool = false
+    @Published private(set) var speechAuthorizationStatus: SFSpeechRecognizerAuthorizationStatus = .notDetermined
+
+    private let audioSession = AVAudioSession.sharedInstance()
+    private var audioRecorder: AVAudioRecorder?
+    private let speechRecognizer: SFSpeechRecognizer?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private var timer: Timer?
+    private var audioFileURL: URL?
+
+    private let maxDuration: TimeInterval = 60
+
+    override init() {
+        speechRecognizer = SFSpeechRecognizer()
+        super.init()
+        requestPermissions()
+    }
+
+    deinit {
+        timer?.invalidate()
+        audioRecorder?.stop()
+        recognitionTask?.cancel()
+        try? audioSession.setActive(false, options: [.notifyOthersOnDeactivation])
+    }
+
+    func requestPermissions() {
+        audioSession.requestRecordPermission { [weak self] granted in
+            DispatchQueue.main.async {
+                self?.hasMicrophonePermission = granted
+                self?.updatePermissionErrorState()
+            }
+        }
+
+        SFSpeechRecognizer.requestAuthorization { [weak self] status in
+            DispatchQueue.main.async {
+                self?.speechAuthorizationStatus = status
+                self?.updatePermissionErrorState()
+            }
+        }
+    }
+
+    func startRecording() {
+        updatePermissionErrorState()
+        guard hasMicrophonePermission else {
+            errorMessage = RecorderError.microphonePermissionDenied.errorDescription
+            requestPermissions()
+            return
+        }
+
+        guard speechAuthorizationStatus == .authorized else {
+            errorMessage = RecorderError.speechPermissionDenied.errorDescription
+            requestPermissions()
+            return
+        }
+
+        guard speechRecognizer?.isAvailable == true else {
+            errorMessage = RecorderError.recognizerUnavailable.errorDescription
+            return
+        }
+
+        do {
+            try configureAudioSession()
+            let url = try makeRecordingURL()
+            audioFileURL = url
+
+            let settings: [String: Any] = [
+                AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+                AVSampleRateKey: 44100,
+                AVNumberOfChannelsKey: 1,
+                AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+            ]
+
+            audioRecorder = try AVAudioRecorder(url: url, settings: settings)
+            audioRecorder?.delegate = self
+            audioRecorder?.isMeteringEnabled = true
+            audioRecorder?.prepareToRecord()
+
+            if audioRecorder?.record(forDuration: maxDuration) == true {
+                DispatchQueue.main.async {
+                    self.transcript = ""
+                    self.elapsedTime = 0
+                    self.isRecording = true
+                    self.errorMessage = nil
+                    self.startTimer()
+                }
+            } else {
+                throw RecorderError.unableToCreateRecorder
+            }
+        } catch {
+            DispatchQueue.main.async {
+                if let recorderError = error as? RecorderError {
+                    self.errorMessage = recorderError.errorDescription
+                } else {
+                    self.errorMessage = RecorderError.unknown.errorDescription
+                }
+                self.isRecording = false
+                self.stopTimer()
+            }
+        }
+    }
+
+    func stopRecording() {
+        guard isRecording else { return }
+        audioRecorder?.stop()
+        stopTimer()
+    }
+
+    func resetTranscript() {
+        transcript = ""
+    }
+
+    private func updatePermissionErrorState() {
+        if !hasMicrophonePermission {
+            errorMessage = RecorderError.microphonePermissionDenied.errorDescription
+        } else if speechAuthorizationStatus != .authorized {
+            errorMessage = RecorderError.speechPermissionDenied.errorDescription
+        } else if let message = errorMessage,
+                  message == RecorderError.microphonePermissionDenied.errorDescription ||
+                    message == RecorderError.speechPermissionDenied.errorDescription {
+            errorMessage = nil
+        }
+    }
+
+    private func configureAudioSession() throws {
+        try audioSession.setCategory(.playAndRecord, mode: .measurement, options: [.duckOthers, .defaultToSpeaker])
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+    }
+
+    private func makeRecordingURL() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+        let filename = UUID().uuidString.appending(".m4a")
+        return directory.appendingPathComponent(filename)
+    }
+
+    private func startTimer() {
+        stopTimer()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            self.elapsedTime += 0.2
+            if self.elapsedTime >= self.maxDuration {
+                self.stopRecording()
+            }
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func handleFinishRecording(successfully flag: Bool) {
+        DispatchQueue.main.async {
+            self.isRecording = false
+            self.stopTimer()
+            self.audioRecorder = nil
+            try? self.audioSession.setActive(false, options: [.notifyOthersOnDeactivation])
+        }
+
+        guard flag, let url = audioFileURL else {
+            DispatchQueue.main.async {
+                self.errorMessage = RecorderError.unknown.errorDescription
+            }
+            cleanupRecordingFile()
+            return
+        }
+
+        transcribeAudio(at: url)
+    }
+
+    private func transcribeAudio(at url: URL) {
+        recognitionTask?.cancel()
+        recognitionTask = nil
+
+        let request = SFSpeechURLRecognitionRequest(url: url)
+        request.shouldReportPartialResults = false
+
+        recognitionTask = speechRecognizer?.recognitionTask(with: request) { [weak self] result, error in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                if let result = result {
+                    self.transcript = result.bestTranscription.formattedString
+                    if result.isFinal {
+                        self.recognitionTask = nil
+                        self.cleanupRecordingFile()
+                    }
+                }
+                if let error = error {
+                    self.errorMessage = error.localizedDescription
+                    self.recognitionTask = nil
+                    self.cleanupRecordingFile()
+                }
+            }
+        }
+    }
+
+    private func cleanupRecordingFile() {
+        if let url = audioFileURL {
+            try? FileManager.default.removeItem(at: url)
+            audioFileURL = nil
+        }
+    }
+}
+
+extension AudioRecorderService: AVAudioRecorderDelegate {
+    func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+        handleFinishRecording(successfully: flag)
+    }
+
+    func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
+        DispatchQueue.main.async {
+            self.errorMessage = error?.localizedDescription ?? RecorderError.unknown.errorDescription
+            self.isRecording = false
+            self.stopTimer()
+        }
+    }
+}

--- a/yummr/CreatePostView.swift
+++ b/yummr/CreatePostView.swift
@@ -60,6 +60,7 @@ struct CreatePostView: View {
     @State private var tagSearchText = ""
     @State private var tagSearchResults: [AppUser] = []
     @State private var pendingTags: [PendingTag] = []
+    @State private var audioTranscript: String = ""
 
     var body: some View {
         NavigationView {
@@ -70,7 +71,8 @@ struct CreatePostView: View {
                             title: $title,
                             description: $description,
                             recipe: $recipe,
-                            selectedImages: $selectedImages
+                            selectedImages: $selectedImages,
+                            audioTranscript: $audioTranscript
                         )
                     } label: {
                         Label("AI Draft", systemImage: "wand.and.stars")
@@ -402,6 +404,10 @@ struct CreatePostView: View {
         if !ingredients.isEmpty {
             extras["ingredients"] = ingredients.joined(separator: ", ")
         }
+        let trimmedTranscript = audioTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedTranscript.isEmpty {
+            extras["aiVoiceTranscript"] = trimmedTranscript
+        }
 
         PostService.shared.uploadPost(
             title: title,
@@ -432,6 +438,7 @@ struct CreatePostView: View {
                 pendingTags = []
                 selectedImages = []
                 selectedPhotos = []
+                audioTranscript = ""
             case .failure(let error):
                 errorMessage = error.localizedDescription
             }


### PR DESCRIPTION
## Summary
- add an AudioRecorderService that coordinates microphone and speech recognition permissions, a 60s AVAudioRecorder session, and SFSpeechRecognizer transcription output
- embed voice capture controls, timer, and editable transcript preview into the AI draft workshop so creators can review captured audio text
- persist any captured transcript with the draft metadata so it can ride along with later AI/Gemini requests

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68ccbfd04aec832387c3576d7f84941e