### PR TITLE
Refine feed UI and integrate AI calorie estimates

### DIFF
--- a/yummr.xcodeproj/project.pbxproj
+++ b/yummr.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+               D12E7A5F2FD4541E00E9CB25 /* AppStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12E7A5E2FD4541E00E9CB25 /* AppStyle.swift */; };
+               D12E7A612FD4547D00E9CB25 /* Post+Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12E7A602FD4547D00E9CB25 /* Post+Metadata.swift */; };
+               D12E7A632FD454BB00E9CB25 /* StarRatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12E7A622FD454BB00E9CB25 /* StarRatingView.swift */; };
 		20EE8CD89FDC41D0A46F8425 /* UserPostsFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACFE0121D6E54FB8907793A3 /* UserPostsFeedView.swift */; };
 		D03A82CF2E0F85C000AA7342 /* yummrApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03A82CE2E0F85C000AA7342 /* yummrApp.swift */; };
 		D03A82D32E0F85C400AA7342 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D03A82D22E0F85C400AA7342 /* Assets.xcassets */; };
@@ -46,6 +49,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+               D12E7A5E2FD4541E00E9CB25 /* AppStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStyle.swift; sourceTree = "<group>"; };
+               D12E7A602FD4547D00E9CB25 /* Post+Metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post+Metadata.swift"; sourceTree = "<group>"; };
+               D12E7A622FD454BB00E9CB25 /* StarRatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarRatingView.swift; sourceTree = "<group>"; };
 		ACFE0121D6E54FB8907793A3 /* UserPostsFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPostsFeedView.swift; sourceTree = "<group>"; };
 		D03A82CB2E0F85C000AA7342 /* yummr.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = yummr.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D03A82CE2E0F85C000AA7342 /* yummrApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = yummrApp.swift; sourceTree = "<group>"; };
@@ -121,11 +127,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		D03A82CD2E0F85C000AA7342 /* yummr */ = {
-			isa = PBXGroup;
-			children = (
-				D0B8C9FE2E7D055400E5233D /* Comment.swift */,
-				D0B8CA012E7D055400E5233D /* CreatePostView.swift */,
+                D03A82CD2E0F85C000AA7342 /* yummr */ = {
+                        isa = PBXGroup;
+                        children = (
+                                D12E7A5E2FD4541E00E9CB25 /* AppStyle.swift */,
+                                D12E7A602FD4547D00E9CB25 /* Post+Metadata.swift */,
+                                D12E7A622FD454BB00E9CB25 /* StarRatingView.swift */,
+                                D0B8C9FE2E7D055400E5233D /* Comment.swift */,
+                                D0B8CA012E7D055400E5233D /* CreatePostView.swift */,
 				D0B8C9F82E7D055300E5233D /* FeedView.swift */,
 				D0B8C9F52E7D055300E5233D /* ProfileView.swift */,
 				D0B8C9F42E7D055200E5233D /* KeychainHelper.swift */,
@@ -260,15 +269,16 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		D03A82C72E0F85C000AA7342 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D0B8CA192E7D08BB00E5233D /* UserService.swift in Sources */,
-				D03E44062E12DE3800FE91E9 /* Comment.swift in Sources */,
-				D0DDE66D2E10084100691496 /* CreatePostView.swift in Sources */,
-				D0DDE65F2E0FD0CB00691496 /* FeedView.swift in Sources */,
-				D03E44002E12C0F600FE91E9 /* ProfileView.swift in Sources */,
+                D03A82C72E0F85C000AA7342 /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                D12E7A5F2FD4541E00E9CB25 /* AppStyle.swift in Sources */,
+                                D0B8CA192E7D08BB00E5233D /* UserService.swift in Sources */,
+                                D03E44062E12DE3800FE91E9 /* Comment.swift in Sources */,
+                                D0DDE66D2E10084100691496 /* CreatePostView.swift in Sources */,
+                                D0DDE65F2E0FD0CB00691496 /* FeedView.swift in Sources */,
+                                D03E44002E12C0F600FE91E9 /* ProfileView.swift in Sources */,
 				D0DDE6612E0FDBB100691496 /* KeychainHelper.swift in Sources */,
 				D0DDE6772E100F4500691496 /* ImagePicker.swift in Sources */,
 				D0B8CA112E7D071900E5233D /* SearchView.swift in Sources */,
@@ -277,16 +287,18 @@
 				D0B8CA142E7D073700E5233D /* CachedWebImage.swift in Sources */,
 				D0B8CA152E7D073700E5233D /* AudioRecorderService.swift in Sources */,
 				D0B8CA0F2E7D070B00E5233D /* AppUser.swift in Sources */,
-				D0B8CA162E7D073700E5233D /* AIRecipeService.swift in Sources */,
-				D0B8CA172E7D073700E5233D /* AIDraftWorkshopView.swift in Sources */,
-				D03E44082E12DFE800FE91E9 /* AllCommentsView.swift in Sources */,
-				D03A834E2E0F8A9500AA7342 /* RootView.swift in Sources */,
+                                D0B8CA162E7D073700E5233D /* AIRecipeService.swift in Sources */,
+                                D0B8CA172E7D073700E5233D /* AIDraftWorkshopView.swift in Sources */,
+                                D12E7A612FD4547D00E9CB25 /* Post+Metadata.swift in Sources */,
+                                D03E44082E12DFE800FE91E9 /* AllCommentsView.swift in Sources */,
+                                D03A834E2E0F8A9500AA7342 /* RootView.swift in Sources */,
 				D03A83502E0F8AAD00AA7342 /* AuthView.swift in Sources */,
 				D0E7494D2E37724C008B42CD /* notes.swift in Sources */,
 				D03A834C2E0F8A7A00AA7342 /* AuthService.swift in Sources */,
-				D03A82CF2E0F85C000AA7342 /* yummrApp.swift in Sources */,
-				D0DDE6652E0FFC9A00691496 /* PostCard.swift in Sources */,
-				D03E44042E12DE2B00FE91E9 /* PostDetailView.swift in Sources */,
+                                D03A82CF2E0F85C000AA7342 /* yummrApp.swift in Sources */,
+                                D0DDE6652E0FFC9A00691496 /* PostCard.swift in Sources */,
+                                D12E7A632FD454BB00E9CB25 /* StarRatingView.swift in Sources */,
+                                D03E44042E12DE2B00FE91E9 /* PostDetailView.swift in Sources */,
 				D0DDE66B2E10081200691496 /* PostService.swift in Sources */,
 				D0DDE6672E10079900691496 /* StorageService.swift in Sources */,
 				D0DDE6632E0FDD7A00691496 /* LoginView.swift in Sources */,

--- a/yummr/AIDraftWorkshopView.swift
+++ b/yummr/AIDraftWorkshopView.swift
@@ -10,6 +10,9 @@ struct AIDraftWorkshopView: View {
     @Binding var selectedImages: [UIImage]
     @Binding var aiReferenceImages: [UIImage]
     @Binding var audioTranscript: String
+    @Binding var cookTime: String
+    @Binding var calorieEstimate: String
+    @Binding var aiNotes: [String]
 
     @State private var ideaPrompt: String = ""
     @State private var capturedIdeas: [String] = []
@@ -21,7 +24,6 @@ struct AIDraftWorkshopView: View {
     @State private var isDraftingWithAI: Bool = false
     @State private var lastGeneratedDate: Date?
     @State private var newIngredientDraft: String = ""
-    @State private var aiNotes: [String] = []
     @State private var referencePhotoItems: [PhotosPickerItem] = []
     @State private var showReferenceCamera: Bool = false
     @State private var capturedReferenceImage: UIImage?
@@ -322,6 +324,14 @@ struct AIDraftWorkshopView: View {
             ingredients = newIngredients
         }
 
+        if let newCookTime = draft.cookTime?.trimmingCharacters(in: .whitespacesAndNewlines), !newCookTime.isEmpty {
+            cookTime = newCookTime
+        }
+
+        if let calories = draft.calorieEstimate, calories > 0 {
+            calorieEstimate = "\(calories)"
+        }
+
         if let steps = draft.instructions, !steps.isEmpty {
             var combined = AttributedString()
             for (index, step) in steps.enumerated() {
@@ -536,6 +546,24 @@ struct AIDraftWorkshopView: View {
                         RoundedRectangle(cornerRadius: 12)
                             .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                     )
+            }
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Cook Time")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                TextField("e.g. 45 minutes", text: $cookTime)
+                    .textFieldStyle(.roundedBorder)
+            }
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Calorie Estimate")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                TextField("Total calories", text: $calorieEstimate)
+                    .keyboardType(.numberPad)
+                    .textFieldStyle(.roundedBorder)
+                Text("Use the AI estimate to give people a sense of the meal's nutrition. Edit if you adjust ingredients.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
             }
         }
     }

--- a/yummr/AIRecipeService.swift
+++ b/yummr/AIRecipeService.swift
@@ -14,6 +14,8 @@ struct AIRecipeDraft: Codable {
     var instructions: [String]?
     let notes: [String]?
     var recipe: String?
+    let cookTime: String?
+    let calorieEstimate: Int?
     var recipeCreativeRanges: [CreativeRange] = []
     var instructionCreativeRanges: [[CreativeRange]] = []
 
@@ -25,6 +27,8 @@ struct AIRecipeDraft: Codable {
         case instructions
         case notes
         case recipe
+        case cookTime
+        case calorieEstimate
     }
 }
 
@@ -253,7 +257,7 @@ final class AIRecipeService {
                 )
             ],
             generationConfig: GeminiRequest.GenerationConfig(
-                temperature: 0.6,
+                temperature: 0.4,
                 topP: 0.95,
                 responseMimeType: "application/json"
             )
@@ -288,7 +292,9 @@ final class AIRecipeService {
 
         sections.append("You are an assistant that turns loose cooking notes into a publishable recipe for the Yummr app.")
         sections.append("Use the following inputs to craft a concise recipe draft.")
-        sections.append("Return only JSON with this structure (replace the placeholders with real values): {\"title\": \"...\", \"summary\": \"...\", \"ingredients\": [\"...\"], \"instructions\": [\"...\"], \"notes\": [\"...\"], \"recipe\": \"...\" }.")
+        sections.append("Return only JSON with this structure (replace the placeholders with real values): {\"title\": \"...\", \"summary\": \"...\", \"ingredients\": [\"...\"], \"instructions\": [\"...\"], \"notes\": [\"...\"], \"recipe\": \"...\", \"cookTime\": \"...\", \"calorieEstimate\": 123 }.")
+        sections.append("calorieEstimate must be a single integer representing the total calories for the recipe you generate based strictly on the ingredients and portions you provide. Do not add units or text.")
+        sections.append("Wrap only the invented or estimated portions of your output in <creative>...</creative> tags so the client can highlight them.")
         sections.append("Do not include markdown, explanations, or any text outside of that JSON object.")
 
         if publicImageCount > 0 {
@@ -328,7 +334,7 @@ final class AIRecipeService {
             sections.append("Author guidance: \(customPrompt)")
         }
 
-        sections.append("Keep instructions actionable and short. Respect any cook times or key flavors mentioned. If information is missing, make reasonable assumptions but keep them labeled as notes.")
+        sections.append("Keep instructions actionable and short. Respect any cook times or key flavors mentioned. If information is missing, make reasonable assumptions but mark those segments inside <creative>...</creative>.")
 
         return sections.joined(separator: "\n\n")
     }

--- a/yummr/AppStyle.swift
+++ b/yummr/AppStyle.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct AppFontModifier: ViewModifier {
+    let style: Font.TextStyle
+    let weight: Font.Weight
+
+    func body(content: Content) -> some View {
+        content
+            .font(.system(style, design: .rounded))
+            .fontWeight(weight)
+    }
+}
+
+extension View {
+    func appTextStyle(_ style: Font.TextStyle, weight: Font.Weight = .regular) -> some View {
+        modifier(AppFontModifier(style: style, weight: weight))
+    }
+}

--- a/yummr/CreatePostView.swift
+++ b/yummr/CreatePostView.swift
@@ -41,6 +41,7 @@ struct CreatePostView: View {
     @State private var description = ""
     @State private var recipe: AttributedString = AttributedString()
     @State private var cookTime = ""
+    @State private var calorieEstimate = ""
     @State private var ingredients: [String] = []
     @State private var ingredientDraft = ""
     @State private var selectedImages: [UIImage] = []
@@ -62,6 +63,7 @@ struct CreatePostView: View {
     @State private var tagSearchResults: [AppUser] = []
     @State private var pendingTags: [PendingTag] = []
     @State private var audioTranscript: String = ""
+    @State private var aiNotes: [String] = []
 
     var body: some View {
         NavigationView {
@@ -75,7 +77,10 @@ struct CreatePostView: View {
                             ingredients: $ingredients,
                             selectedImages: $selectedImages,
                             aiReferenceImages: $aiReferenceImages,
-                            audioTranscript: $audioTranscript
+                            audioTranscript: $audioTranscript,
+                            cookTime: $cookTime,
+                            calorieEstimate: $calorieEstimate,
+                            aiNotes: $aiNotes
                         )
                     } label: {
                         Label("AI Draft", systemImage: "wand.and.stars")
@@ -115,6 +120,10 @@ struct CreatePostView: View {
 
                         TextField("Cook time (e.g. 45 minutes)", text: $cookTime)
                             .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                        TextField("Calories (estimated)", text: $calorieEstimate)
+                            .keyboardType(.numberPad)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
                     }
 
                     ingredientsSection
@@ -126,6 +135,25 @@ struct CreatePostView: View {
                     }
                     .disabled(isUploading || selectedImages.isEmpty || title.isEmpty)
                     .buttonStyle(.borderedProminent)
+
+                    if !aiNotes.isEmpty {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("AI Notes")
+                                .appTextStyle(.headline, weight: .semibold)
+                            ForEach(aiNotes, id: \.self) { note in
+                                HStack(alignment: .top, spacing: 8) {
+                                    Image(systemName: "lightbulb.fill")
+                                        .foregroundColor(.accentColor)
+                                        .font(.footnote)
+                                    Text(note)
+                                        .appTextStyle(.body)
+                                }
+                            }
+                        }
+                        .padding()
+                        .background(Color(UIColor.secondarySystemBackground))
+                        .cornerRadius(12)
+                    }
 
                     if let error = errorMessage {
                         Text("Error: \(error)")
@@ -416,6 +444,15 @@ struct CreatePostView: View {
             extras["aiVoiceTranscript"] = trimmedTranscript
         }
 
+        let trimmedCalories = calorieEstimate.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedCalories.isEmpty {
+            extras["calorieEstimate"] = trimmedCalories
+        }
+
+        if !aiNotes.isEmpty {
+            extras["aiNotes"] = aiNotes.joined(separator: "\n")
+        }
+
         let recipeText = recipe.plainText.trimmingCharacters(in: .whitespacesAndNewlines)
 
         PostService.shared.uploadPost(
@@ -449,6 +486,8 @@ struct CreatePostView: View {
                 selectedPhotos = []
                 audioTranscript = ""
                 aiReferenceImages = []
+                calorieEstimate = ""
+                aiNotes = []
             case .failure(let error):
                 errorMessage = error.localizedDescription
             }

--- a/yummr/Post+Metadata.swift
+++ b/yummr/Post+Metadata.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+extension Post {
+    var starRating: Double? {
+        parseDouble(forKeys: ["rating", "starRating", "stars"])
+    }
+
+    var isFavorited: Bool {
+        guard let value = extraFields?["isFavorite"] ?? extraFields?["favorite"] else {
+            return false
+        }
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized == "true" || normalized == "1" || normalized == "yes"
+    }
+
+    var calorieEstimate: Int? {
+        guard let raw = extraFields?["calorieEstimate"] ?? extraFields?["calories"] else {
+            return nil
+        }
+        let digits = raw.compactMap { $0.isNumber ? $0 : nil }
+        guard let parsed = Int(String(digits)) else { return nil }
+        return parsed
+    }
+
+    var formattedCalories: String? {
+        guard let calories = calorieEstimate else { return nil }
+        return "\(calories) kcal"
+    }
+
+    var notesList: [String] {
+        let raw = extraFields?["notes"] ?? extraFields?["aiNotes"] ?? ""
+        return parseList(from: raw)
+    }
+
+    var ingredientList: [String] {
+        guard let raw = extraFields?["ingredients"] else { return [] }
+        return parseList(from: raw)
+    }
+
+    var instructionsList: [String] {
+        guard let recipe else { return [] }
+        return recipe
+            .components(separatedBy: CharacterSet.newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private func parseDouble(forKeys keys: [String]) -> Double? {
+        for key in keys {
+            if let value = extraFields?[key] {
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                if let number = Double(trimmed) {
+                    return number
+                }
+                let digits = trimmed.compactMap { $0.isNumber ? $0 : ($0 == "." ? $0 : nil) }
+                if let number = Double(String(digits)) {
+                    return number
+                }
+            }
+        }
+        return nil
+    }
+
+    private func parseList(from string: String) -> [String] {
+        string
+            .components(separatedBy: CharacterSet(charactersIn: ",\n•"))
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+}

--- a/yummr/PostCard.swift
+++ b/yummr/PostCard.swift
@@ -1,14 +1,12 @@
 import SwiftUI
 import FirebaseAuth
 import FirebaseFirestore
-import FirebaseFirestore 
 
 struct PostCard: View {
     var post: Post
     @State private var likeCount: Int
     @State private var isLiked: Bool
     @State private var isProcessingLike = false
-    @State private var previewComments: [Comment] = []
     @State private var showAllComments = false
     @State private var commentCount = 0
     @State private var showTagsOverlay = false
@@ -22,100 +20,108 @@ struct PostCard: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(post.title)
-                .font(.headline)
+        VStack(alignment: .leading, spacing: 16) {
+            header
 
-            NavigationLink(destination: ProfileView(userID: post.authorID)) {
-                Text("By \(post.authorName)")
-                    .font(.subheadline)
-                    .foregroundColor(.blue)
+            if let caption = captionText {
+                Text(caption)
+                    .appTextStyle(.body)
+                    .foregroundColor(.primary)
             }
-            .buttonStyle(.plain)
 
             tabbedImages
 
-            if let cookTime = post.cookTime, !cookTime.isEmpty {
-                Label(cookTime, systemImage: "clock")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-
-            Text(post.description)
-                .font(.body)
-
-            if !post.taggedUserIDs.isEmpty {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 12) {
-                        ForEach(sortedTaggedUsers, id: \.handle) { user in
-                            NavigationLink(destination: ProfileView(userID: user.id ?? "")) {
-                                Text("@\(user.handle)")
-                                    .padding(.horizontal, 12)
-                                    .padding(.vertical, 6)
-                                    .background(Color.blue.opacity(0.1))
-                                    .cornerRadius(12)
-                            }
-                            .buttonStyle(.plain)
-                        }
+            if !post.photoTags.isEmpty {
+                Button {
+                    withAnimation(.easeInOut) {
+                        showTagsOverlay.toggle()
                     }
+                } label: {
+                    Label(showTagsOverlay ? "Hide tags" : "Show tags", systemImage: showTagsOverlay ? "tag.fill" : "tag")
+                        .appTextStyle(.caption, weight: .medium)
+                        .foregroundColor(.accentColor)
                 }
+                .buttonStyle(.plain)
             }
 
-            HStack(spacing: 10) {
-                Button(action: toggleLike) {
-                    Image(systemName: isLiked ? "heart.fill" : "heart")
-                        .foregroundColor(isLiked ? .red : .gray)
-                }
-                Text("\(likeCount)")
-                    .foregroundColor(.gray)
-                    .font(.subheadline)
-
-                Spacer()
-
-                if !post.photoTags.isEmpty {
-                    Button {
-                        withAnimation {
-                            showTagsOverlay.toggle()
-                        }
-                    } label: {
-                        Image(systemName: showTagsOverlay ? "tag.fill" : "tag")
-                    }
-                }
-            }
-            .padding(.top, 4)
-
-            VStack(alignment: .leading, spacing: 6) {
-                ForEach(previewComments.prefix(2)) { comment in
-                    commentRow(comment)
-                }
-
-                if commentCount > 2 {
-                    Button("View all comments") {
-                        showAllComments = true
-                    }
-                    .font(.caption)
-                    .foregroundColor(.blue)
-                }
-
-                Button("Open comments") {
-                    showAllComments = true
-                }
-                .font(.caption)
-                .foregroundColor(.blue)
-            }
+            interactionBar
         }
         .padding()
         .background(Color(UIColor.systemGray6))
-        .cornerRadius(12)
+        .cornerRadius(16)
         .onAppear {
-            fetchPreviewComments()
+            fetchCommentCount()
             fetchTaggedUsers()
         }
         .sheet(isPresented: $showAllComments, onDismiss: {
-            fetchPreviewComments()
+            fetchCommentCount()
         }) {
             AllCommentsView(post: post)
         }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 8) {
+                Text(post.title)
+                    .appTextStyle(.title3, weight: .semibold)
+                    .foregroundColor(.primary)
+                    .multilineTextAlignment(.leading)
+
+                Spacer()
+
+                if let rating = post.starRating {
+                    StarRatingView(rating: rating)
+                }
+
+                if post.isFavorited {
+                    Image(systemName: "star.fill")
+                        .foregroundColor(.yellow)
+                        .font(.caption)
+                        .accessibilityLabel("Favorited")
+                }
+            }
+
+            Text("by \(post.authorName)")
+                .appTextStyle(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private var interactionBar: some View {
+        HStack(spacing: 16) {
+            Button(action: toggleLike) {
+                HStack(spacing: 6) {
+                    Image(systemName: isLiked ? "heart.fill" : "heart")
+                        .foregroundColor(isLiked ? .red : .secondary)
+                    Text("\(likeCount)")
+                        .appTextStyle(.subheadline, weight: .medium)
+                        .foregroundColor(.primary)
+                }
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+
+            Button {
+                showAllComments = true
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "bubble.right")
+                        .foregroundColor(.secondary)
+                    Text(commentCount == 0 ? "Comment" : "\(commentCount) comments")
+                        .appTextStyle(.subheadline, weight: .medium)
+                        .foregroundColor(.accentColor)
+                }
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.top, 4)
+    }
+
+    private var captionText: String? {
+        let trimmed = post.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private var tabbedImages: some View {
@@ -129,6 +135,7 @@ struct PostCard: View {
                         .aspectRatio(contentMode: .fill)
                         .frame(width: geometry.size.width, height: geometry.size.height)
                         .clipped()
+
                         if showTagsOverlay {
                             ForEach(tags(for: item.offset), id: \.id) { tag in
                                 tagOverlay(tag: tag, geometry: geometry)
@@ -137,7 +144,7 @@ struct PostCard: View {
                     }
                 }
                 .frame(height: 300)
-                .cornerRadius(12)
+                .cornerRadius(16)
                 .padding(.bottom, 4)
                 .tag(item.offset)
             }
@@ -153,7 +160,7 @@ struct PostCard: View {
         return Group {
             if let position = position {
                 Text(label)
-                    .font(.caption2)
+                    .appTextStyle(.caption2, weight: .semibold)
                     .padding(6)
                     .background(Color.black.opacity(0.7))
                     .foregroundColor(.white)
@@ -183,36 +190,38 @@ struct PostCard: View {
         return "@\(tag.userID.prefix(6))"
     }
 
-    private var sortedTaggedUsers: [AppUser] {
-        post.taggedUserIDs.compactMap { taggedUsers[$0] }
+    private func fetchCommentCount() {
+        guard let postID = post.id else { return }
+        Firestore.firestore()
+            .collection("posts")
+            .document(postID)
+            .collection("comments")
+            .order(by: "timestamp", descending: false)
+            .limit(to: 5)
+            .getDocuments { snapshot, error in
+                if let error = error {
+                    print("Preview comments fetch error:", error)
+                    return
+                }
+                guard let docs = snapshot?.documents else { return }
+                commentCount = docs.count
+            }
     }
 
-    private func commentRow(_ comment: Comment) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            NavigationLink(destination: ProfileView(userID: comment.authorID)) {
-                Text(comment.authorName)
-                    .font(.caption)
-                    .foregroundColor(.blue)
-            }
-            .buttonStyle(.plain)
-
-            highlightMentions(in: comment.text)
-                .font(.caption)
-        }
-    }
-
-    private func highlightMentions(in text: String) -> Text {
-        let parts = text.split(separator: " ")
-        var composed = Text("")
-        for part in parts {
-            if part.hasPrefix("@") {
-                let mention = String(part)
-                composed = composed + Text(" \(mention)").foregroundColor(.blue)
-            } else {
-                composed = composed + Text(" \(part)")
+    private func fetchTaggedUsers() {
+        let ids = post.taggedUserIDs
+        guard !ids.isEmpty else { return }
+        UserService.shared.fetchUsers(withIDs: ids) { users in
+            DispatchQueue.main.async {
+                var map: [String: AppUser] = [:]
+                for user in users {
+                    if let id = user.id {
+                        map[id] = user
+                    }
+                }
+                taggedUsers = map
             }
         }
-        return composed
     }
 
     private func toggleLike() {
@@ -229,46 +238,6 @@ struct PostCard: View {
                     print("Failed to like post: \(error)")
                 }
                 isProcessingLike = false
-            }
-        }
-    }
-
-    private func fetchPreviewComments() {
-        guard let postID = post.id else { return }
-        Firestore.firestore()
-            .collection("posts")
-            .document(postID)
-            .collection("comments")
-            .order(by: "timestamp", descending: false)
-            .limit(to: 5)
-            .getDocuments { snapshot, error in
-                if let error = error {
-                    print("Preview comments fetch error:", error)
-                    return
-                }
-                guard let docs = snapshot?.documents else { return }
-                do {
-                    let allComments: [Comment] = try docs.map { try $0.data(as: Comment.self) }
-                    self.commentCount = allComments.count
-                    self.previewComments = Array(allComments.prefix(2))
-                } catch {
-                    print("Preview comments decode error:", error)
-                }
-            }
-    }
-
-    private func fetchTaggedUsers() {
-        let ids = post.taggedUserIDs
-        guard !ids.isEmpty else { return }
-        UserService.shared.fetchUsers(withIDs: ids) { users in
-            DispatchQueue.main.async {
-                var map: [String: AppUser] = [:]
-                for user in users {
-                    if let id = user.id {
-                        map[id] = user
-                    }
-                }
-                self.taggedUsers = map
             }
         }
     }

--- a/yummr/PostDetailView.swift
+++ b/yummr/PostDetailView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import FirebaseFirestore
-import FirebaseFirestore
 
 struct PostDetailView: View {
     let post: Post
@@ -27,69 +26,34 @@ struct PostDetailView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 20) {
+                header
                 imageCarousel
-
-                if let cookTime = post.cookTime, !cookTime.isEmpty {
-                    Label(cookTime, systemImage: "clock")
-                        .font(.headline)
+                if let caption = captionText {
+                    Text(caption)
+                        .appTextStyle(.body)
+                        .foregroundColor(.primary)
                 }
-
-                Text(post.description)
-                    .font(.body)
-
-                if let recipe = post.recipe, !recipe.isEmpty {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Recipe")
-                            .font(.title3)
-                            .bold()
-                        Text(recipe)
-                            .font(.body)
-                            .multilineTextAlignment(.leading)
-                    }
+                metaRow
+                if !post.notesList.isEmpty {
+                    infoSection(title: "Notes", items: post.notesList)
                 }
-
-                if let ingredients = post.extraFields?["ingredients"], !ingredients.isEmpty {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Ingredients")
-                            .font(.headline)
-                        Text(ingredients)
-                            .font(.body)
-                    }
+                if !post.ingredientList.isEmpty {
+                    infoSection(title: "Ingredients", items: post.ingredientList)
                 }
-
-                if !post.taggedUserIDs.isEmpty {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Tagged")
-                            .font(.headline)
-                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 120), spacing: 12)]) {
-                            ForEach(sortedTaggedUsers, id: \.handle) { user in
-                                NavigationLink(destination: ProfileView(userID: user.id ?? "")) {
-                                    VStack {
-                                        Text(user.displayName)
-                                            .font(.subheadline)
-                                        Text("@\(user.handle)")
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                    }
-                                    .padding()
-                                    .frame(maxWidth: .infinity)
-                                    .background(Color(UIColor.secondarySystemBackground))
-                                    .cornerRadius(12)
-                                }
-                                .buttonStyle(.plain)
-                            }
-                        }
-                    }
+                if !post.instructionsList.isEmpty {
+                    instructionsSection
+                } else if let recipeText = post.recipe, !recipeText.isEmpty {
+                    Text(recipeText)
+                        .appTextStyle(.body)
+                        .foregroundColor(.primary)
                 }
-
-                Divider()
-
                 commentSection
             }
             .padding()
         }
         .navigationTitle(post.title)
+        .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             fetchComments()
             fetchTaggedUsers()
@@ -97,6 +61,50 @@ struct PostDetailView: View {
         .onChange(of: newComment, perform: updateMentionSuggestions)
         .sheet(isPresented: $showAllComments) {
             AllCommentsView(post: post)
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center, spacing: 12) {
+                Text(post.title)
+                    .appTextStyle(.title2, weight: .bold)
+                    .foregroundColor(.primary)
+                Spacer()
+                if let rating = post.starRating {
+                    StarRatingView(rating: rating)
+                }
+                if post.isFavorited {
+                    Image(systemName: "star.fill")
+                        .foregroundColor(.yellow)
+                        .font(.caption)
+                }
+            }
+            Text("by \(post.authorName)")
+                .appTextStyle(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private var captionText: String? {
+        let trimmed = post.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private var metaRow: some View {
+        let cookTime = post.cookTime?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let calories = post.formattedCalories
+        return HStack(spacing: 16) {
+            if let cookTime, !cookTime.isEmpty {
+                Label(cookTime, systemImage: "clock")
+                    .appTextStyle(.subheadline, weight: .medium)
+                    .foregroundColor(.secondary)
+            }
+            if let calories {
+                Label(calories, systemImage: "flame")
+                    .appTextStyle(.subheadline, weight: .medium)
+                    .foregroundColor(.secondary)
+            }
         }
     }
 
@@ -131,9 +139,35 @@ struct PostDetailView: View {
                 Button {
                     withAnimation { showTagsOverlay.toggle() }
                 } label: {
-                    Label(showTagsOverlay ? "Hide tags" : "Show tags", systemImage: showTagsOverlay ? "eye.slash" : "tag")
+                    Label(showTagsOverlay ? "Hide tags" : "Show tags", systemImage: showTagsOverlay ? "tag.fill" : "tag")
+                        .appTextStyle(.caption, weight: .medium)
+                        .foregroundColor(.accentColor)
                 }
-                .font(.caption)
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func infoSection(title: String, items: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .appTextStyle(.headline, weight: .semibold)
+            ForEach(items, id: \.self) { item in
+                Text("• \(item)")
+                    .appTextStyle(.body)
+                    .foregroundColor(.primary)
+            }
+        }
+    }
+
+    private var instructionsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Instructions")
+                .appTextStyle(.headline, weight: .semibold)
+            ForEach(Array(post.instructionsList.enumerated()), id: \.offset) { index, step in
+                Text("\(index + 1). \(step)")
+                    .appTextStyle(.body)
+                    .foregroundColor(.primary)
             }
         }
     }
@@ -159,7 +193,7 @@ struct PostDetailView: View {
         return Group {
             if let position = position {
                 Text(tagLabel(for: tag))
-                    .font(.caption2)
+                    .appTextStyle(.caption2, weight: .semibold)
                     .padding(6)
                     .background(Color.black.opacity(0.7))
                     .foregroundColor(.white)
@@ -182,171 +216,85 @@ struct PostDetailView: View {
         return "@\(tag.userID.prefix(6))"
     }
 
-    private var sortedTaggedUsers: [AppUser] {
-        post.taggedUserIDs.compactMap { taggedUsers[$0] }
-    }
-
     private var commentSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Text("Comments")
-                    .font(.headline)
+                    .appTextStyle(.headline, weight: .semibold)
                 Spacer()
                 Button("View thread") { showAllComments = true }
-                    .font(.caption)
+                    .appTextStyle(.caption, weight: .medium)
             }
 
             ForEach(comments) { comment in
                 VStack(alignment: .leading, spacing: 4) {
                     NavigationLink(destination: ProfileView(userID: comment.authorID)) {
                         Text(comment.authorName)
-                            .font(.caption)
-                            .foregroundColor(.blue)
+                            .appTextStyle(.caption, weight: .semibold)
+                            .foregroundColor(.accentColor)
                     }
                     .buttonStyle(.plain)
+
                     highlightMentions(in: comment.text)
-                        .font(.body)
+                        .appTextStyle(.callout)
+
+                    Text(comment.timestamp.formatted(date: .abbreviated, time: .shortened))
+                        .appTextStyle(.caption2)
+                        .foregroundColor(.secondary)
                 }
-                .padding(8)
-                .background(Color(UIColor.systemGray6))
-                .cornerRadius(8)
+                .padding(.vertical, 6)
+                Divider()
             }
 
-            VStack(alignment: .leading, spacing: 8) {
-                TextField("Add a comment...", text: $newComment, axis: .vertical)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
+            commentComposer
+        }
+    }
 
-                if !mentionSuggestions.isEmpty {
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack {
-                            ForEach(mentionSuggestions, id: \.handle) { user in
-                                Button(action: { insertMention(user) }) {
-                                    Text("@\(user.handle)")
-                                        .padding(6)
-                                        .background(Color.blue.opacity(0.1))
-                                        .cornerRadius(8)
-                                }
-                                .buttonStyle(.plain)
+    private var commentComposer: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Add a comment")
+                .appTextStyle(.subheadline, weight: .semibold)
+            TextField("Share your thoughts…", text: $newComment, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+            if !mentionSuggestions.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 12) {
+                        ForEach(mentionSuggestions, id: \.id) { suggestion in
+                            Button {
+                                insertMention(suggestion)
+                            } label: {
+                                Text("@\(suggestion.handle)")
+                                    .appTextStyle(.caption)
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 6)
+                                    .background(Color.accentColor.opacity(0.1))
+                                    .cornerRadius(12)
                             }
                         }
                     }
                 }
-
-                Button("Send") {
-                    submitComment()
-                }
-                .disabled(newComment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
+            Button("Post Comment", action: postComment)
+                .buttonStyle(.borderedProminent)
+                .disabled(newComment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
     }
 
     private func highlightMentions(in text: String) -> Text {
-        let components = text.split(separator: " ")
-        var aggregated = Text("")
-        for component in components {
-            if component.hasPrefix("@") {
-                aggregated = aggregated + Text(" \(component)").foregroundColor(.blue)
+        let parts = text.split(separator: " ")
+        var composed = Text("")
+        for (index, part) in parts.enumerated() {
+            if index > 0 {
+                composed = composed + Text(" ")
+            }
+            if part.hasPrefix("@") {
+                let mention = String(part)
+                composed = composed + Text(mention).foregroundColor(.accentColor)
             } else {
-                aggregated = aggregated + Text(" \(component)")
+                composed = composed + Text(String(part))
             }
         }
-        return aggregated
-    }
-
-    private func updateMentionSuggestions(for text: String) {
-        let words = text.split(separator: " ")
-        guard let last = words.last, last.hasPrefix("@"), last.count > 1 else {
-            mentionSuggestions = []
-            return
-        }
-        let query = last.dropFirst().lowercased()
-        UserService.shared.searchUsers(matching: String(query)) { users in
-            DispatchQueue.main.async {
-                mentionSuggestions = users
-                users.forEach { user in
-                    if let id = user.id {
-                        mentionLookup[user.handle] = id
-                    }
-                }
-            }
-        }
-    }
-
-    private func insertMention(_ user: AppUser) {
-        let handle = user.handle
-        var components = newComment.split(separator: " ", omittingEmptySubsequences: false)
-        if components.isEmpty {
-            newComment = "@\(handle) "
-        } else {
-            components.removeLast()
-            components.append(Substring("@\(handle)"))
-            newComment = components.joined(separator: " ") + " "
-        }
-        mentionSuggestions = []
-        if let id = user.id {
-            mentionLookup[handle] = id
-        }
-    }
-
-    private func submitComment() {
-        guard let postID = post.id,
-              let uid = auth.currentUser?.uid,
-              let name = auth.currentUser?.displayName ?? auth.currentUser?.email else { return }
-
-        resolveTaggedUserIDs(in: newComment) { taggedIDs in
-            let ref = Firestore.firestore()
-                .collection("posts")
-                .document(postID)
-                .collection("comments")
-                .document()
-
-            let comment = Comment(
-                id: ref.documentID,
-                text: newComment.trimmingCharacters(in: .whitespacesAndNewlines),
-                authorID: uid,
-                authorName: name,
-                parentCommentID: nil,
-                taggedUserIDs: taggedIDs,
-                timestamp: nil
-            )
-
-            do {
-                try ref.setData(from: comment)
-                newComment = ""
-                mentionSuggestions = []
-            } catch {
-                print("Failed to add comment: \(error)")
-            }
-        }
-    }
-
-    private func resolveTaggedUserIDs(in text: String, completion: @escaping ([String]) -> Void) {
-        let handles = Set(text.split(separator: " ").filter { $0.hasPrefix("@") }.map { String($0.dropFirst()) })
-        guard !handles.isEmpty else {
-            completion([])
-            return
-        }
-
-        var resolved: [String] = []
-        let group = DispatchGroup()
-
-        for handle in handles {
-            if let cached = mentionLookup[handle] {
-                resolved.append(cached)
-                continue
-            }
-            group.enter()
-            UserService.shared.fetchUser(withHandle: handle) { user in
-                if let id = user?.id {
-                    resolved.append(id)
-                }
-                group.leave()
-            }
-        }
-
-        group.notify(queue: .main) {
-            completion(Array(Set(resolved)))
-        }
+        return composed
     }
 
     private func fetchComments() {
@@ -356,9 +304,18 @@ struct PostDetailView: View {
             .document(postID)
             .collection("comments")
             .order(by: "timestamp", descending: false)
-            .addSnapshotListener { snapshot, _ in
+            .getDocuments { snapshot, error in
+                if let error = error {
+                    print("Error fetching comments: \(error)")
+                    return
+                }
+
                 guard let docs = snapshot?.documents else { return }
-                self.comments = docs.compactMap { try? $0.data(as: Comment.self) }
+                do {
+                    comments = try docs.map { try $0.data(as: Comment.self) }
+                } catch {
+                    print("Failed to decode comments: \(error)")
+                }
             }
     }
 
@@ -373,8 +330,76 @@ struct PostDetailView: View {
                         map[id] = user
                     }
                 }
-                self.taggedUsers = map
+                taggedUsers = map
             }
         }
+    }
+
+    private func insertMention(_ user: AppUser) {
+        let handle = "@\(user.handle)"
+        let trimmed = newComment.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty {
+            newComment = handle + " "
+        } else {
+            newComment += " " + handle + " "
+        }
+        mentionSuggestions = []
+        mentionLookup[handle] = user.id
+    }
+
+    private func updateMentionSuggestions(_ text: String) {
+        guard let lastWord = text.split(separator: " ").last, lastWord.hasPrefix("@") else {
+            mentionSuggestions = []
+            return
+        }
+
+        let query = lastWord.replacingOccurrences(of: "@", with: "")
+        guard !query.isEmpty else {
+            mentionSuggestions = []
+            return
+        }
+
+        UserService.shared.searchUsers(matching: String(query)) { users in
+            DispatchQueue.main.async {
+                mentionSuggestions = users
+            }
+        }
+    }
+
+    private func postComment() {
+        guard let postID = post.id else { return }
+        let text = newComment.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+
+        var payload: [String: Any] = [
+            "text": text,
+            "timestamp": Timestamp(date: Date())
+        ]
+
+        if let user = auth.currentUser {
+            payload["authorID"] = user.id
+            payload["authorName"] = user.displayName
+        }
+
+        let mentions = mentionLookup
+        if !mentions.isEmpty {
+            payload["mentionedUsers"] = mentions
+        }
+
+        Firestore.firestore()
+            .collection("posts")
+            .document(postID)
+            .collection("comments")
+            .addDocument(data: payload) { error in
+                if let error = error {
+                    print("Error posting comment: \(error)")
+                    return
+                }
+
+                newComment = ""
+                mentionSuggestions = []
+                mentionLookup = [:]
+                fetchComments()
+            }
     }
 }

--- a/yummr/PostDetailView.swift
+++ b/yummr/PostDetailView.swift
@@ -238,9 +238,11 @@ struct PostDetailView: View {
                     highlightMentions(in: comment.text)
                         .appTextStyle(.callout)
 
-                    Text(comment.timestamp.formatted(date: .abbreviated, time: .shortened))
-                        .appTextStyle(.caption2)
-                        .foregroundColor(.secondary)
+                    if let timestamp = comment.timestamp {
+                        Text(timestamp.formatted(date: .abbreviated, time: .shortened))
+                            .appTextStyle(.caption2)
+                            .foregroundColor(.secondary)
+                    }
                 }
                 .padding(.vertical, 6)
                 Divider()
@@ -344,7 +346,9 @@ struct PostDetailView: View {
             newComment += " " + handle + " "
         }
         mentionSuggestions = []
-        mentionLookup[handle] = user.id
+        if let id = user.id {
+            mentionLookup[handle] = id
+        }
     }
 
     private func updateMentionSuggestions(_ text: String) {
@@ -377,8 +381,8 @@ struct PostDetailView: View {
         ]
 
         if let user = auth.currentUser {
-            payload["authorID"] = user.id
-            payload["authorName"] = user.displayName
+            payload["authorID"] = user.uid
+            payload["authorName"] = user.displayName ?? user.email ?? "Anonymous"
         }
 
         let mentions = mentionLookup

--- a/yummr/StarRatingView.swift
+++ b/yummr/StarRatingView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct StarRatingView: View {
+    let rating: Double
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(0..<5, id: \.self) { index in
+                Image(systemName: symbol(for: index))
+                    .foregroundColor(.yellow)
+                    .font(.caption2)
+            }
+            Text(String(format: "%.1f", rating))
+                .appTextStyle(.caption2, weight: .semibold)
+                .foregroundColor(.secondary)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Rated \(String(format: "%.1f", rating)) out of five stars")
+    }
+
+    private func symbol(for index: Int) -> String {
+        let threshold = rating - Double(index)
+        if threshold >= 1 { return "star.fill" }
+        if threshold >= 0.5 { return "star.leadinghalf.filled" }
+        return "star"
+    }
+}


### PR DESCRIPTION
## Summary
- restyle the feed card to emphasise title, AI rating/favorite state, caption, and simplify social controls
- enrich the post detail view with cook time, calorie estimate, notes, ingredients, and streamlined comments using new Post metadata helpers
- extend the AI workshop/create flow to capture cook time, Gemini-powered calorie estimates, highlight invented text, and adopt rounded app typography

## Testing
- `xcodebuild -project yummr.xcodeproj -scheme yummr -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15' build` *(fails: xcodebuild not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68edc7dcfd74832399b660c0f1aa513a