### PR TITLE
Improve Gemini key fallback and camera availability feedback

### DIFF
--- a/docs/shared-gemini-key-setup.md
+++ b/docs/shared-gemini-key-setup.md
@@ -1,0 +1,40 @@
+# Shared Gemini API Key Setup
+
+Follow these steps to publish a single Gemini API key that every user in the app can use. The instructions are split into three short sections so you always know where the key lives, what the app expects, and the minimum code that has to be in your build.
+
+## 1. Keep the Placeholder in the Bundle
+
+* File: `yummr/GeminiSecrets.plist`
+* Current value: `THIS-IS-THE-KEY`
+* Purpose: a last-resort fallback if the Firestore document and the local keychain are both empty.
+
+> ✅ Leave the placeholder in place and **do not** check your real key into source control. The bundle fallback keeps the app from crashing but isn’t meant for production use.
+
+## 2. Publish the Shared Key in Firestore
+
+1. Open the Firebase console → **Firestore Database** → stay on the **Data** tab.
+2. Create the collection `appConfig` if it doesn’t exist yet.
+3. Inside `appConfig`, add a document with the ID `publicSecrets`.
+4. Add a **string** field named `geminiAPIKey` and paste your real Gemini key as the value. You can use the placeholder `"YOUR-REAL-KEY"` while testing the flow.
+5. Click **Save**. You should now see the path `appConfig / publicSecrets` with the `geminiAPIKey` field displayed.
+6. Back in the app, open **Settings → AI Drafting** and tap **Reload shared key** so the client downloads and caches the new value.
+
+What happens behind the scenes:
+
+* `SecretsService.resolveSharedGeminiAPIKey()` requests `appConfig/publicSecrets`.
+* On success, the service stores the key in the keychain for fast reuse.
+* `AIRecipeService` uses the cached key when generating drafts.
+
+If Firestore doesn’t have the document yet, the Settings screen shows a placeholder and drafting fails gracefully.
+
+## 3. Minimum Code & Rules Required
+
+Make sure these pieces are included in your build so the Firestore lookup works:
+
+* `yummr/SecretsService.swift` — fetches `/appConfig/publicSecrets` and caches the key.
+* `yummr/AIRecipeService.swift` (updated `loadAPIKey()`) — calls the secrets service before trying the bundled plist or environment variable.
+* `yummr/SettingsView.swift` — shows the shared key status and provides the **Reload shared key** button.
+* `firebase/firestore.rules` — allows public read access to `/appConfig/**` while keeping writes locked down.
+* `yummr/GeminiSecrets.plist` — keep the `THIS-IS-THE-KEY` placeholder as a reminder and fallback.
+
+Once those files and the Firestore document are in place, every signed-in user automatically receives the same Gemini API key from Firestore without exposing the secret in your repo.

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -1,0 +1,58 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    match /users/{userId} {
+      allow read: if isSignedIn();
+      allow create: if isSignedIn() && request.auth.uid == userId;
+      allow update, delete: if isSignedIn() && request.auth.uid == userId;
+
+      match /collections/{collectionId} {
+        allow read, write: if isSignedIn() && request.auth.uid == userId;
+      }
+
+      match /friends/{friendId} {
+        allow read: if isSignedIn() && (request.auth.uid == userId || request.auth.uid == friendId);
+        allow write: if isSignedIn() && (request.auth.uid == userId || request.auth.uid == friendId);
+      }
+
+      match /friendRequests/{requesterId} {
+        allow read: if isSignedIn() && request.auth.uid == userId;
+        allow create: if isSignedIn() && request.auth.uid == requesterId;
+        allow delete: if isSignedIn() && (request.auth.uid == userId || request.auth.uid == requesterId);
+      }
+
+      match /private/{document=**} {
+        allow read, write: if isSignedIn() && request.auth.uid == userId;
+      }
+    }
+
+    match /posts/{postId} {
+      allow read: if true;
+      allow create: if isSignedIn() && request.auth.uid == request.resource.data.authorID;
+      allow update: if isSignedIn()
+        && resource.data.authorID == request.auth.uid
+        && request.resource.data.authorID == resource.data.authorID;
+      allow delete: if isSignedIn() && resource.data.authorID == request.auth.uid;
+
+      match /comments/{commentId} {
+        allow read: if true;
+        allow create: if isSignedIn() && request.auth.uid == request.resource.data.authorID;
+        allow update: if isSignedIn()
+          && (request.auth.uid == resource.data.authorID
+              || request.auth.uid == get(/databases/$(database)/documents/posts/$(postId)).data.authorID);
+        allow delete: if isSignedIn()
+          && (request.auth.uid == resource.data.authorID
+              || request.auth.uid == get(/databases/$(database)/documents/posts/$(postId)).data.authorID);
+      }
+    }
+
+    match /appConfig/{document=**} {
+      allow read: if true;
+      allow write: if false;
+    }
+  }
+}

--- a/firebase/storage.rules
+++ b/firebase/storage.rules
@@ -1,0 +1,28 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    match /images/{allPaths=**} {
+      allow read: if true;
+      allow write: if isSignedIn();
+    }
+
+    match /profileImages/{fileName} {
+      allow read: if true;
+      allow write: if isSignedIn() && request.auth.uid == fileName.split('.')[0];
+    }
+
+    match /bannerImages/{fileName} {
+      allow read: if true;
+      allow write: if isSignedIn() && request.auth.uid == fileName.split('.')[0];
+    }
+
+    match /{allPaths=**} {
+      allow read: if isSignedIn();
+      allow write: if false;
+    }
+  }
+}

--- a/yummr.xcodeproj/project.pbxproj
+++ b/yummr.xcodeproj/project.pbxproj
@@ -32,17 +32,26 @@
 		D0B8CA122E7D073700E5233D /* SplashScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B8C9F92E7D055300E5233D /* SplashScreenView.swift */; };
 		D0B8CA132E7D073700E5233D /* RichTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B8C9FD2E7D055400E5233D /* RichTextEditor.swift */; };
 		D0B8CA142E7D073700E5233D /* CachedWebImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B8C9FF2E7D055400E5233D /* CachedWebImage.swift */; };
-		D0B8CA152E7D073700E5233D /* AudioRecorderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B8CA0A2E7D055500E5233D /* AudioRecorderService.swift */; };
-		D0B8CA162E7D073700E5233D /* AIRecipeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B8C9F02E7D055200E5233D /* AIRecipeService.swift */; };
-		D0B8CA172E7D073700E5233D /* AIDraftWorkshopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B8CA0D2E7D055500E5233D /* AIDraftWorkshopView.swift */; };
-		D0B8CA192E7D08BB00E5233D /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B8CA182E7D08BB00E5233D /* UserService.swift */; };
+               D0B8CA152E7D073700E5233D /* AudioRecorderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B8CA0A2E7D055500E5233D /* AudioRecorderService.swift */; };
+               D0B8CA162E7D073700E5233D /* AIRecipeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B8C9F02E7D055200E5233D /* AIRecipeService.swift */; };
+               D0B8CA172E7D073700E5233D /* AIDraftWorkshopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B8CA0D2E7D055500E5233D /* AIDraftWorkshopView.swift */; };
+               D0F9B2B02F12A1BC00FF1234 /* SecretsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0F9B2AF2F12A1BC00FF1234 /* SecretsService.swift */; };
+               D0B8CA192E7D08BB00E5233D /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B8CA182E7D08BB00E5233D /* UserService.swift */; };
 		D0DDE65D2E0FD0BA00691496 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE65C2E0FD0BA00691496 /* Post.swift */; };
 		D0DDE65F2E0FD0CB00691496 /* FeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE65E2E0FD0CB00691496 /* FeedView.swift */; };
 		D0DDE6612E0FDBB100691496 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE6602E0FDBB100691496 /* KeychainHelper.swift */; };
 		D0DDE6632E0FDD7A00691496 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE6622E0FDD7A00691496 /* LoginView.swift */; };
 		D0DDE6652E0FFC9A00691496 /* PostCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE6642E0FFC9A00691496 /* PostCard.swift */; };
 		D0DDE6672E10079900691496 /* StorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE6662E10079800691496 /* StorageService.swift */; };
-		D0DDE66B2E10081200691496 /* PostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE66A2E10080900691496 /* PostService.swift */; };
+               D0DDE66B2E10081200691496 /* PostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE66A2E10080900691496 /* PostService.swift */; };
+               5245134BD0E741E2A95C1C90 /* NotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51C871FB7FE4EE2B4554E47 /* NotificationsView.swift */; };
+               0CB419EB6677440CA3AD552C /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F171E00D663D4900A4ECFD7B /* NotificationService.swift */; };
+               6BF2E2F13D41420D8B5A10E5 /* FriendService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBDC2B27884E4BD7879DDB73 /* FriendService.swift */; };
+               C284E4E8223A47A38505BBC5 /* HandleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5486A9A2CD47E99906DA89 /* HandleFormatter.swift */; };
+               D7AB5B5E980146F5B73918CA /* EditPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF6198539F34F74B48EA21F /* EditPostView.swift */; };
+               62F092BB75CF4A9A98364E01 /* SavedCollectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ABFBACA75FF45F2BE2030BB /* SavedCollectionsView.swift */; };
+               1B45E95F97BF43F1B2BF2F8B /* SavedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE5FA22DE454CBCA73BD79F /* SavedService.swift */; };
+               DC69BA63FA2F47199A218B19 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46FE71A60344F01B95942B5 /* SettingsView.swift */; };
 		D0DDE66D2E10084100691496 /* CreatePostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE66C2E10084100691496 /* CreatePostView.swift */; };
 		D0DDE6772E100F4500691496 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDE6762E100F4500691496 /* ImagePicker.swift */; };
 		D0E7494D2E37724C008B42CD /* notes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E7494C2E377245008B42CD /* notes.swift */; };
@@ -77,10 +86,11 @@
 		D0B8C9FE2E7D055400E5233D /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		D0B8C9FF2E7D055400E5233D /* CachedWebImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedWebImage.swift; sourceTree = "<group>"; };
 		D0B8CA012E7D055400E5233D /* CreatePostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePostView.swift; sourceTree = "<group>"; };
-		D0B8CA0A2E7D055500E5233D /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
-		D0B8CA0B2E7D055500E5233D /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
-		D0B8CA0D2E7D055500E5233D /* AIDraftWorkshopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIDraftWorkshopView.swift; sourceTree = "<group>"; };
-		D0B8CA0E2E7D070B00E5233D /* AppUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUser.swift; sourceTree = "<group>"; };
+               D0B8CA0A2E7D055500E5233D /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
+               D0B8CA0B2E7D055500E5233D /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
+               D0B8CA0D2E7D055500E5233D /* AIDraftWorkshopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIDraftWorkshopView.swift; sourceTree = "<group>"; };
+               D0F9B2AF2F12A1BC00FF1234 /* SecretsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretsService.swift; sourceTree = "<group>"; };
+               D0B8CA0E2E7D070B00E5233D /* AppUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUser.swift; sourceTree = "<group>"; };
 		D0B8CA102E7D071900E5233D /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		D0B8CA182E7D08BB00E5233D /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
 		D0DDE65C2E0FD0BA00691496 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
@@ -92,7 +102,15 @@
 		D0DDE66A2E10080900691496 /* PostService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostService.swift; sourceTree = "<group>"; };
 		D0DDE66C2E10084100691496 /* CreatePostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePostView.swift; sourceTree = "<group>"; };
 		D0DDE6762E100F4500691496 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
-		D0E7494C2E377245008B42CD /* notes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = notes.swift; sourceTree = "<group>"; };
+               D0E7494C2E377245008B42CD /* notes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = notes.swift; sourceTree = "<group>"; };
+               C51C871FB7FE4EE2B4554E47 /* NotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsView.swift; sourceTree = "<group>"; };
+               F171E00D663D4900A4ECFD7B /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+               FBDC2B27884E4BD7879DDB73 /* FriendService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendService.swift; sourceTree = "<group>"; };
+               DD5486A9A2CD47E99906DA89 /* HandleFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandleFormatter.swift; sourceTree = "<group>"; };
+               6FF6198539F34F74B48EA21F /* EditPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPostView.swift; sourceTree = "<group>"; };
+               2ABFBACA75FF45F2BE2030BB /* SavedCollectionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedCollectionsView.swift; sourceTree = "<group>"; };
+               DCE5FA22DE454CBCA73BD79F /* SavedService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedService.swift; sourceTree = "<group>"; };
+               C46FE71A60344F01B95942B5 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -170,10 +188,19 @@
                                 D03A82DC2E0F865900AA7342 /* GoogleService-Info.plist */,
                                 4BF1CEA6F29C4242173CE3B0 /* GeminiSecrets.plist */,
                                 D03A82D42E0F85C400AA7342 /* Preview Content */,
-				D03A834B2E0F8A7900AA7342 /* AuthService.swift */,
-				D03A834D2E0F8A9500AA7342 /* RootView.swift */,
-				D03A834F2E0F8AAD00AA7342 /* AuthView.swift */,
-			);
+                                D03A834B2E0F8A7900AA7342 /* AuthService.swift */,
+                                D03A834D2E0F8A9500AA7342 /* RootView.swift */,
+                                D03A834F2E0F8AAD00AA7342 /* AuthView.swift */,
+                                C51C871FB7FE4EE2B4554E47 /* NotificationsView.swift */,
+                                F171E00D663D4900A4ECFD7B /* NotificationService.swift */,
+                                FBDC2B27884E4BD7879DDB73 /* FriendService.swift */,
+                                DD5486A9A2CD47E99906DA89 /* HandleFormatter.swift */,
+                                6FF6198539F34F74B48EA21F /* EditPostView.swift */,
+                                2ABFBACA75FF45F2BE2030BB /* SavedCollectionsView.swift */,
+                                DCE5FA22DE454CBCA73BD79F /* SavedService.swift */,
+                                D0F9B2AF2F12A1BC00FF1234 /* SecretsService.swift */,
+                                C46FE71A60344F01B95942B5 /* SettingsView.swift */,
+                        );
 			path = yummr;
 			sourceTree = "<group>";
 		};
@@ -299,12 +326,21 @@
                                 D0DDE6652E0FFC9A00691496 /* PostCard.swift in Sources */,
                                 D12E7A632FD454BB00E9CB25 /* StarRatingView.swift in Sources */,
                                 D03E44042E12DE2B00FE91E9 /* PostDetailView.swift in Sources */,
-				D0DDE66B2E10081200691496 /* PostService.swift in Sources */,
-				D0DDE6672E10079900691496 /* StorageService.swift in Sources */,
-				D0DDE6632E0FDD7A00691496 /* LoginView.swift in Sources */,
-				20EE8CD89FDC41D0A46F8425 /* UserPostsFeedView.swift in Sources */,
-				D0DDE65D2E0FD0BA00691496 /* Post.swift in Sources */,
-			);
+                                D0DDE66B2E10081200691496 /* PostService.swift in Sources */,
+                                D0DDE6672E10079900691496 /* StorageService.swift in Sources */,
+                                D0DDE6632E0FDD7A00691496 /* LoginView.swift in Sources */,
+                                20EE8CD89FDC41D0A46F8425 /* UserPostsFeedView.swift in Sources */,
+                                D0DDE65D2E0FD0BA00691496 /* Post.swift in Sources */,
+                                5245134BD0E741E2A95C1C90 /* NotificationsView.swift in Sources */,
+                                0CB419EB6677440CA3AD552C /* NotificationService.swift in Sources */,
+                                6BF2E2F13D41420D8B5A10E5 /* FriendService.swift in Sources */,
+                                C284E4E8223A47A38505BBC5 /* HandleFormatter.swift in Sources */,
+                                D7AB5B5E980146F5B73918CA /* EditPostView.swift in Sources */,
+                                62F092BB75CF4A9A98364E01 /* SavedCollectionsView.swift in Sources */,
+                                1B45E95F97BF43F1B2BF2F8B /* SavedService.swift in Sources */,
+                                D0F9B2B02F12A1BC00FF1234 /* SecretsService.swift in Sources */,
+                                DC69BA63FA2F47199A218B19 /* SettingsView.swift in Sources */,
+                        );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
@@ -442,8 +478,9 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Savor.;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.food-and-drink";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Explain why Savor needs microphone access (e.g., To record your cooking notes).";
-				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Explain why Savor performs speech recognition (e.g., To transcribe your recorded notes).";
+                                INFOPLIST_KEY_NSCameraUsageDescription = "Savor needs camera access so you can capture photos and videos of your dishes.";
+                                INFOPLIST_KEY_NSMicrophoneUsageDescription = "Savor uses the microphone to record your cooking notes and audio prompts.";
+                                INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Savor converts your recorded cooking notes to text with speech recognition.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -454,7 +491,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = jakubwozny.yummr;
+                            PRODUCT_BUNDLE_IDENTIFIER = com.jakubwozny.yummr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -475,8 +512,9 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Savor.;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.food-and-drink";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Explain why Savor needs microphone access (e.g., To record your cooking notes).";
-				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Explain why Savor performs speech recognition (e.g., To transcribe your recorded notes).";
+                                INFOPLIST_KEY_NSCameraUsageDescription = "Savor needs camera access so you can capture photos and videos of your dishes.";
+                                INFOPLIST_KEY_NSMicrophoneUsageDescription = "Savor uses the microphone to record your cooking notes and audio prompts.";
+                                INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Savor converts your recorded cooking notes to text with speech recognition.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -487,7 +525,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = jakubwozny.yummr;
+                            PRODUCT_BUNDLE_IDENTIFIER = com.jakubwozny.yummr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/yummr/AIDraftWorkshopView.swift
+++ b/yummr/AIDraftWorkshopView.swift
@@ -754,7 +754,13 @@ struct AIDraftWorkshopView_Previews: PreviewProvider {
                 ingredients: .constant(["sweet potatoes", "poached eggs", "chimichurri"]),
                 selectedImages: .constant([]),
                 aiReferenceImages: .constant([]),
-                audioTranscript: .constant("Toast bread. Layer greens. Finish with lemon zest.")
+                audioTranscript: .constant("Toast bread. Layer greens. Finish with lemon zest."),
+                cookTime: .constant("25 minutes"),
+                calorieEstimate: .constant("520"),
+                aiNotes: .constant([
+                    "Consider swapping sweet potatoes for roasted squash in fall.",
+                    "Offer a dairy-free chimichurri option with olive oil only."
+                ])
             )
         }
     }

--- a/yummr/AIRecipeService.swift
+++ b/yummr/AIRecipeService.swift
@@ -115,7 +115,6 @@ final class AIRecipeService {
         let error: GeminiAPIError
     }
 
-    private static let apiKeyKey = "ai.gemini.apiKey"
     private let session: URLSession
     private let modelName = "gemini-1.5-flash"
     private let baseURL = "https://generativelanguage.googleapis.com/v1beta/models"
@@ -135,7 +134,7 @@ final class AIRecipeService {
         images: [UIImage],
         referenceImages: [UIImage]
     ) async throws -> AIRecipeDraft {
-        guard let apiKey = loadAPIKey() else { throw ServiceError.missingAPIKey }
+        let apiKey = try await loadAPIKey()
         let endpoint = "\(baseURL)/\(modelName):generateContent?key=\(apiKey)"
         guard let url = URL(string: endpoint) else { throw ServiceError.invalidURL }
 
@@ -178,9 +177,14 @@ final class AIRecipeService {
         }
     }
 
-    private func loadAPIKey() -> String? {
-        if let storedKey = sanitizedKey(from: KeychainHelper.load(Self.apiKeyKey)) {
-            return storedKey
+    private func loadAPIKey() async throws -> String {
+        if let cached = SecretsService.shared.cachedGeminiAPIKey() {
+            return cached
+        }
+
+        if let remote = try? await SecretsService.shared.resolveSharedGeminiAPIKey(),
+           let sanitizedRemote = sanitizedKey(from: remote) {
+            return sanitizedRemote
         }
 
         if let secretsURL = Bundle.main.url(forResource: "GeminiSecrets", withExtension: "plist"),
@@ -195,7 +199,7 @@ final class AIRecipeService {
             return sanitizedEnvironmentKey
         }
 
-        return nil
+        throw ServiceError.missingAPIKey
     }
 
     private func sanitizedKey(from rawKey: String?) -> String? {
@@ -204,7 +208,7 @@ final class AIRecipeService {
             return nil
         }
 
-        KeychainHelper.save(Self.apiKeyKey, trimmed)
+        SecretsService.shared.cacheGeminiAPIKey(trimmed)
         return trimmed
     }
 

--- a/yummr/AllCommentsView.swift
+++ b/yummr/AllCommentsView.swift
@@ -221,7 +221,8 @@ struct AllCommentsView: View {
         let normalizedHandle = HandleFormatter.normalizedHandle(from: user.handle)
         guard normalizedHandle.count > 1 else { return }
         if let id = user.id {
-            mentionLookup[String(normalizedHandle.dropFirst())] = id
+            let bare = String(normalizedHandle.dropFirst()).lowercased()
+            mentionLookup[bare] = id
         }
 
         var tokens = newComment.split(separator: " ", omittingEmptySubsequences: false)
@@ -247,7 +248,7 @@ struct AllCommentsView: View {
                 mentionSuggestions = users
                 users.forEach { user in
                     if let id = user.id {
-                        mentionLookup[user.handle] = id
+                        mentionLookup[user.handle.lowercased()] = id
                     }
                 }
             }
@@ -302,35 +303,72 @@ struct AllCommentsView: View {
     }
 
     private func resolveTaggedUserIDs(in text: String, completion: @escaping ([String]) -> Void) {
-        let handles = Set(text.split(separator: " ")
-            .filter { $0.hasPrefix("@") }
-            .map { String($0.dropFirst()) })
+        var uniqueHandles: [String: String] = [:]
+        for token in text.split(separator: " ") where token.hasPrefix("@") {
+            let stripped = String(token.dropFirst())
+            guard !stripped.isEmpty else { continue }
+            let lower = stripped.lowercased()
+            if uniqueHandles[lower] == nil {
+                uniqueHandles[lower] = stripped
+            }
+        }
 
-        guard !handles.isEmpty else {
+        guard !uniqueHandles.isEmpty else {
             completion([])
             return
         }
 
+        let syncQueue = DispatchQueue(label: "AllCommentsView.resolveTaggedUserIDs")
         var resolved: [String] = []
         let group = DispatchGroup()
 
-        for handle in handles {
-            if let cached = mentionLookup[handle] {
-                resolved.append(cached)
+        func appendResolved(_ id: String) {
+            syncQueue.async {
+                resolved.append(id)
+            }
+        }
+
+        for (lower, original) in uniqueHandles {
+            if let cached = mentionLookup[lower] {
+                appendResolved(cached)
                 continue
             }
 
             group.enter()
-            UserService.shared.fetchUser(withHandle: handle) { user in
+            UserService.shared.fetchUser(withHandle: original) { user in
                 if let id = user?.id {
-                    resolved.append(id)
+                    appendResolved(id)
+                    DispatchQueue.main.async {
+                        mentionLookup[lower] = id
+                    }
+                    group.leave()
+                    return
                 }
-                group.leave()
+
+                let fallback = original.lowercased()
+                guard fallback != original else {
+                    group.leave()
+                    return
+                }
+
+                UserService.shared.fetchUser(withHandle: fallback) { fallbackUser in
+                    if let id = fallbackUser?.id {
+                        appendResolved(id)
+                        DispatchQueue.main.async {
+                            mentionLookup[lower] = id
+                        }
+                    }
+                    group.leave()
+                }
             }
         }
 
         group.notify(queue: .main) {
-            completion(Array(Set(resolved)))
+            var final: [String] = []
+            syncQueue.sync {
+                final = resolved
+            }
+            completion(Array(Set(final)))
         }
     }
 

--- a/yummr/AuthService.swift
+++ b/yummr/AuthService.swift
@@ -14,8 +14,15 @@ class AuthService: ObservableObject {
     init() {
         self.currentUser = Auth.auth().currentUser
 
+        if let user = self.currentUser {
+            UserService.shared.ensureUserDocument(for: user)
+        }
+
         Auth.auth().addStateDidChangeListener { _, user in
             self.currentUser = user
+            if let user = user {
+                UserService.shared.ensureUserDocument(for: user)
+            }
         }
     }
 
@@ -26,6 +33,9 @@ class AuthService: ObservableObject {
             if let error = error {
                 completion(false, error.localizedDescription)
             } else {
+                if let user = result?.user {
+                    UserService.shared.ensureUserDocument(for: user)
+                }
                 self.currentUser = result?.user
                 completion(true, nil)
             }
@@ -48,6 +58,11 @@ class AuthService: ObservableObject {
                     } else {
                         // Refresh currentUser so displayName is populated
                         self.currentUser = Auth.auth().currentUser
+                        if let refreshed = self.currentUser {
+                            UserService.shared.ensureUserDocument(for: refreshed, displayName: displayName)
+                        } else {
+                            UserService.shared.ensureUserDocument(for: user, displayName: displayName)
+                        }
                         completion(true, nil)
                     }
                 }

--- a/yummr/CreatePostView.swift
+++ b/yummr/CreatePostView.swift
@@ -42,6 +42,8 @@ struct CreatePostView: View {
     @State private var recipe: AttributedString = AttributedString()
     @State private var cookTime = ""
     @State private var calorieEstimate = ""
+    @State private var starRating: Double = 0
+    @State private var isFavorite = false
     @State private var ingredients: [String] = []
     @State private var ingredientDraft = ""
     @State private var selectedImages: [UIImage] = []
@@ -54,6 +56,7 @@ struct CreatePostView: View {
     @State private var errorMessage: String?
 
     @State private var showCameraPicker = false
+    @State private var cameraUnavailableAlert = false
     @State private var capturedImage: UIImage?
 
     @State private var taggingMode: TaggingMode = .post
@@ -124,6 +127,8 @@ struct CreatePostView: View {
                         TextField("Calories (estimated)", text: $calorieEstimate)
                             .keyboardType(.numberPad)
                             .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                        ratingSection
                     }
 
                     ingredientsSection
@@ -175,6 +180,11 @@ struct CreatePostView: View {
         .sheet(isPresented: $showCameraPicker) {
             ImagePicker(image: $capturedImage, sourceType: .camera)
         }
+        .alert("Camera unavailable", isPresented: $cameraUnavailableAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text("This device can't capture photos right now. Try selecting images from your library instead.")
+        }
         .onChange(of: selectedPhotos) { items in
             Task {
                 selectedImages = []
@@ -203,6 +213,26 @@ struct CreatePostView: View {
                     tagSearchResults = users
                 }
             }
+        }
+    }
+
+    private var ratingSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Your rating")
+                .font(.headline)
+
+            HStack(alignment: .center, spacing: 12) {
+                Slider(value: $starRating, in: 0...5, step: 0.5) {
+                    Text("Star rating")
+                }
+                Text(String(format: "%.1f ★", starRating))
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .frame(width: 72, alignment: .trailing)
+                    .accessibilityHidden(true)
+            }
+
+            Toggle("Mark as favorite", isOn: $isFavorite)
         }
     }
 
@@ -255,11 +285,14 @@ struct CreatePostView: View {
                 }
 
                 Button {
-                    showCameraPicker = true
+                    if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                        showCameraPicker = true
+                    } else {
+                        cameraUnavailableAlert = true
+                    }
                 } label: {
                     Label("Capture Photo", systemImage: "camera")
                 }
-                .disabled(!UIImagePickerController.isSourceTypeAvailable(.camera))
             }
 
             if !selectedImages.isEmpty {
@@ -467,6 +500,15 @@ struct CreatePostView: View {
             extras["aiNotes"] = aiNotes.joined(separator: "\n")
         }
 
+        let roundedRating = (starRating * 10).rounded() / 10
+        if roundedRating > 0 {
+            extras["starRating"] = String(format: "%.1f", roundedRating)
+        }
+
+        if isFavorite {
+            extras["isFavorite"] = "true"
+        }
+
         let recipeText = recipe.plainText.trimmingCharacters(in: .whitespacesAndNewlines)
         let sanitizedSteps = sanitizedInstructionSteps(from: recipeText)
         let recipePayload = sanitizedSteps.isEmpty ? nil : sanitizedSteps.joined(separator: "\n")
@@ -503,6 +545,8 @@ struct CreatePostView: View {
                 audioTranscript = ""
                 aiReferenceImages = []
                 calorieEstimate = ""
+                starRating = 0
+                isFavorite = false
                 aiNotes = []
             case .failure(let error):
                 errorMessage = error.localizedDescription

--- a/yummr/EditPostView.swift
+++ b/yummr/EditPostView.swift
@@ -9,6 +9,8 @@ struct EditPostView: View {
     @State private var ingredients: [String]
     @State private var instructions: [String]
     @State private var aiNotes: String
+    @State private var starRating: Double
+    @State private var isFavorite: Bool
     @State private var isSaving = false
     @State private var errorMessage: String?
 
@@ -18,6 +20,8 @@ struct EditPostView: View {
         _ingredients = State(initialValue: post.wrappedValue.ingredientList)
         _instructions = State(initialValue: post.wrappedValue.instructionsList)
         _aiNotes = State(initialValue: post.wrappedValue.extraFields?["aiNotes"] ?? "")
+        _starRating = State(initialValue: min(max(post.wrappedValue.starRating ?? 0, 0), 5))
+        _isFavorite = State(initialValue: post.wrappedValue.isFavorited)
     }
 
     var body: some View {
@@ -64,6 +68,23 @@ struct EditPostView: View {
                     TextField("Optional notes", text: $aiNotes, axis: .vertical)
                 }
 
+                Section("Rating & Favorites") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack(spacing: 12) {
+                            Slider(value: $starRating, in: 0...5, step: 0.5) {
+                                Text("Star rating")
+                            }
+                            Text(String(format: "%.1f ★", starRating))
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                                .frame(width: 72, alignment: .trailing)
+                                .accessibilityHidden(true)
+                        }
+
+                        Toggle("Mark as favorite", isOn: $isFavorite)
+                    }
+                }
+
                 if let errorMessage {
                     Section {
                         Text(errorMessage)
@@ -102,6 +123,22 @@ struct EditPostView: View {
         var extras = post.extraFields ?? [:]
         extras["ingredients"] = ingredients.joined(separator: "\n")
         extras["aiNotes"] = aiNotes
+
+        let roundedRating = (starRating * 10).rounded() / 10
+        if roundedRating > 0 {
+            extras["starRating"] = String(format: "%.1f", roundedRating)
+        } else {
+            extras.removeValue(forKey: "starRating")
+            extras.removeValue(forKey: "rating")
+            extras.removeValue(forKey: "stars")
+        }
+
+        if isFavorite {
+            extras["isFavorite"] = "true"
+        } else {
+            extras.removeValue(forKey: "isFavorite")
+            extras.removeValue(forKey: "favorite")
+        }
 
         PostService.shared.updatePost(postID: postID,
                                       title: post.title,

--- a/yummr/FriendService.swift
+++ b/yummr/FriendService.swift
@@ -19,6 +19,21 @@ final class FriendService: ObservableObject {
             }
     }
 
+    func fetchFriendIDs(for uid: String, completion: @escaping (Result<[String], Error>) -> Void) {
+        db.collection("users")
+            .document(uid)
+            .collection("friends")
+            .getDocuments { snapshot, error in
+                if let error = error {
+                    completion(.failure(error))
+                    return
+                }
+
+                let ids = snapshot?.documents.compactMap { $0.documentID } ?? []
+                completion(.success(ids))
+            }
+    }
+
     func observeIncomingRequests(for uid: String, listener: @escaping ([String]) -> Void) -> ListenerRegistration {
         db.collection("users")
             .document(uid)
@@ -83,7 +98,12 @@ final class FriendService: ObservableObject {
             .document(requesterUID)
         batch.deleteDocument(requestRef)
 
-        batch.commit(completion: completion)
+        batch.commit { error in
+            if error == nil {
+                self.incrementFriendCounts(for: [currentUID, requesterUID], delta: 1)
+            }
+            completion?(error)
+        }
     }
 
     func removeFriend(_ friendUID: String, completion: ((Error?) -> Void)? = nil) {
@@ -99,6 +119,24 @@ final class FriendService: ObservableObject {
             .collection("friends").document(currentUID)
         batch.deleteDocument(currentRef)
         batch.deleteDocument(otherRef)
-        batch.commit(completion: completion)
+        batch.commit { error in
+            if error == nil {
+                self.incrementFriendCounts(for: [currentUID, friendUID], delta: -1)
+            }
+            completion?(error)
+        }
+    }
+
+    private func incrementFriendCounts(for uids: [String], delta: Int64) {
+        guard delta != 0 else { return }
+        let batch = db.batch()
+        uids.forEach { uid in
+            let userRef = db.collection("users").document(uid)
+            batch.setData([
+                "followerCount": FieldValue.increment(delta),
+                "followingCount": FieldValue.increment(delta)
+            ], forDocument: userRef, merge: true)
+        }
+        batch.commit(completion: nil)
     }
 }

--- a/yummr/GeminiSecrets.plist
+++ b/yummr/GeminiSecrets.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
     <key>GeminiAPIKey</key>
-    <string>YOUR_GEMINI_API_KEY</string>
+    <string>THIS-IS-THE-KEY</string>
 </dict>
 </plist>

--- a/yummr/HandleFormatter.swift
+++ b/yummr/HandleFormatter.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HandleFormatter {
-    static func normalizedHandle(from rawValue: String) -> String {
+    private static func normalizedHandleValue(from rawValue: String) -> String {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return rawValue }
 
@@ -13,10 +13,14 @@ enum HandleFormatter {
         return "@" + trimmed
     }
 
+    static func normalizedHandle(from rawValue: String) -> String {
+        normalizedHandleValue(from: rawValue)
+    }
+
     static func normalizedHandle(from optional: String?) -> String? {
         guard let optional else { return nil }
-        let trimmed = optional.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        return normalizedHandle(from: trimmed)
+        let trimmedValue = optional.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedValue.isEmpty else { return nil }
+        return normalizedHandleValue(from: trimmedValue)
     }
 }

--- a/yummr/PostCard.swift
+++ b/yummr/PostCard.swift
@@ -108,9 +108,12 @@ struct PostCard: View {
                 }
             }
 
-            Text("by \(HandleFormatter.normalizedHandle(from: post.authorName))")
-                .appTextStyle(.caption)
-                .foregroundColor(.secondary)
+            NavigationLink(destination: ProfileView(userID: post.authorID)) {
+                Text("by \(HandleFormatter.normalizedHandle(from: post.authorName))")
+                    .appTextStyle(.caption)
+                    .foregroundColor(.accentColor)
+            }
+            .buttonStyle(.plain)
         }
     }
 

--- a/yummr/PostDetailView.swift
+++ b/yummr/PostDetailView.swift
@@ -116,9 +116,13 @@ struct PostDetailView: View {
                         .font(.caption)
                 }
             }
-            Text("by \(HandleFormatter.normalizedHandle(from: livePost.authorName))")
-                .appTextStyle(.caption)
-                .foregroundColor(.secondary)
+
+            NavigationLink(destination: ProfileView(userID: livePost.authorID)) {
+                Text("by \(HandleFormatter.normalizedHandle(from: livePost.authorName))")
+                    .appTextStyle(.caption)
+                    .foregroundColor(.accentColor)
+            }
+            .buttonStyle(.plain)
         }
     }
 
@@ -294,6 +298,8 @@ struct PostDetailView: View {
                 .appTextStyle(.subheadline, weight: .semibold)
             TextField("Share your thoughts…", text: $newComment, axis: .vertical)
                 .textFieldStyle(.roundedBorder)
+                .submitLabel(.send)
+                .onSubmit(postComment)
             if !mentionSuggestions.isEmpty {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 12) {
@@ -362,7 +368,8 @@ struct PostDetailView: View {
         }
         mentionSuggestions = []
         if let id = user.id {
-            mentionLookup[handle] = id
+            let bare = handle.hasPrefix("@") ? String(handle.dropFirst()) : handle
+            mentionLookup[bare.lowercased()] = id
         }
     }
 
@@ -381,6 +388,11 @@ struct PostDetailView: View {
         UserService.shared.searchUsers(matching: String(query)) { users in
             DispatchQueue.main.async {
                 mentionSuggestions = users
+                for user in users {
+                    if let id = user.id {
+                        mentionLookup[user.handle.lowercased()] = id
+                    }
+                }
             }
         }
     }
@@ -398,34 +410,104 @@ struct PostDetailView: View {
             let authorHandle = HandleFormatter.normalizedHandle(from: appUser?.handle)
                 ?? HandleFormatter.normalizedHandle(from: fallbackName)
 
-            DispatchQueue.main.async {
-                var payload: [String: Any] = [
-                    "text": text,
-                    "timestamp": Timestamp(date: Date()),
-                    "authorID": user.uid,
-                    "authorName": authorHandle
-                ]
-
-                let mentions = mentionLookup
-                if !mentions.isEmpty {
-                    payload["mentionedUsers"] = mentions
-                }
-
-                Firestore.firestore()
+            resolveTaggedUserIDs(in: text) { taggedIDs in
+                let collection = Firestore.firestore()
                     .collection("posts")
                     .document(postID)
                     .collection("comments")
-                    .addDocument(data: payload) { error in
-                        if let error = error {
-                            print("Error posting comment: \(error)")
-                            return
-                        }
 
+                let document = collection.document()
+                let comment = Comment(
+                    id: document.documentID,
+                    text: text,
+                    authorID: user.uid,
+                    authorName: authorHandle,
+                    parentCommentID: nil,
+                    taggedUserIDs: taggedIDs,
+                    timestamp: Date()
+                )
+
+                do {
+                    try document.setData(from: comment)
+                    DispatchQueue.main.async {
                         newComment = ""
                         mentionSuggestions = []
                         mentionLookup = [:]
                     }
+                } catch {
+                    print("Error posting comment: \(error)")
+                }
             }
+        }
+    }
+
+    private func resolveTaggedUserIDs(in text: String, completion: @escaping ([String]) -> Void) {
+        var uniqueHandles: [String: String] = [:]
+        for token in text.split(separator: " ") where token.hasPrefix("@") {
+            let stripped = String(token.dropFirst())
+            guard !stripped.isEmpty else { continue }
+            let lower = stripped.lowercased()
+            if uniqueHandles[lower] == nil {
+                uniqueHandles[lower] = stripped
+            }
+        }
+
+        guard !uniqueHandles.isEmpty else {
+            completion([])
+            return
+        }
+
+        let syncQueue = DispatchQueue(label: "PostDetailView.resolveTaggedUserIDs")
+        var resolved: [String] = []
+        let group = DispatchGroup()
+
+        func appendResolved(_ id: String) {
+            syncQueue.async {
+                resolved.append(id)
+            }
+        }
+
+        for (lower, original) in uniqueHandles {
+            if let cached = mentionLookup[lower] {
+                appendResolved(cached)
+                continue
+            }
+
+            group.enter()
+            UserService.shared.fetchUser(withHandle: original) { user in
+                if let id = user?.id {
+                    appendResolved(id)
+                    DispatchQueue.main.async {
+                        mentionLookup[lower] = id
+                    }
+                    group.leave()
+                    return
+                }
+
+                let fallback = original.lowercased()
+                guard fallback != original else {
+                    group.leave()
+                    return
+                }
+
+                UserService.shared.fetchUser(withHandle: fallback) { fallbackUser in
+                    if let id = fallbackUser?.id {
+                        appendResolved(id)
+                        DispatchQueue.main.async {
+                            mentionLookup[lower] = id
+                        }
+                    }
+                    group.leave()
+                }
+            }
+        }
+
+        group.notify(queue: .main) {
+            var final: [String] = []
+            syncQueue.sync {
+                final = resolved
+            }
+            completion(Array(Set(final)))
         }
     }
 

--- a/yummr/PostService.swift
+++ b/yummr/PostService.swift
@@ -83,7 +83,8 @@ class PostService: ObservableObject {
             return
         }
 
-        resolveAuthorName(for: uid) { authorName in
+        resolveAuthorName(for: uid) { [weak self] authorName in
+            guard let self = self else { return }
             var urls: [String] = Array(repeating: "", count: images.count)
             var detailURLs: [String] = Array(repeating: "", count: detailImages.count)
             var uploadError: Error?
@@ -100,7 +101,7 @@ class PostService: ObservableObject {
                 }
 
                 let imageID = UUID().uuidString
-                let imageRef = storage.reference().child("images/\(imageID).jpg")
+                let imageRef = self.storage.reference().child("images/\(imageID).jpg")
                 let uploadTask = imageRef.putData(imageData, metadata: nil)
 
                 uploadTask.observe(.progress) { snapshot in
@@ -139,7 +140,7 @@ class PostService: ObservableObject {
                 }
 
                 let imageID = UUID().uuidString
-                let imageRef = storage.reference().child("images/detail/\(imageID).jpg")
+                let imageRef = self.storage.reference().child("images/detail/\(imageID).jpg")
                 imageRef.putData(imageData, metadata: nil) { _, error in
                     if let error = error {
                         uploadError = error
@@ -164,7 +165,8 @@ class PostService: ObservableObject {
                 }
 
                 let uniqueTagged = Array(Set(taggedUserIDs))
-                let sanitizedExtras = extraFields.isEmpty ? nil : extraFields
+                let cleanedExtras = self.sanitizeExtraFields(extraFields)
+                let sanitizedExtras = cleanedExtras.isEmpty ? nil : cleanedExtras
                 let sanitizedDetailURLs = detailURLs.isEmpty ? nil : detailURLs
 
                 let post = Post(
@@ -236,25 +238,19 @@ class PostService: ObservableObject {
                     recipeSteps: [String],
                     extraFields: [String: String],
                     completion: @escaping (Result<Void, Error>) -> Void) {
-        var sanitizedExtras = extraFields
-        let sanitizedIngredients = sanitizeIngredients(extraFields["ingredients"])
-        if !sanitizedIngredients.isEmpty {
-            sanitizedExtras["ingredients"] = sanitizedIngredients.joined(separator: ", ")
-        }
-
+        let sanitizedExtras = sanitizeExtraFields(extraFields)
         let sanitizedRecipe = sanitizeInstructions(recipeSteps)
         let recipeString = sanitizedRecipe.joined(separator: "\n")
 
         var payload: [String: Any] = [
             "description": description,
-            "recipe": recipeString
+            "recipe": recipeString,
+            "extraFields": sanitizedExtras
         ]
 
         if let title = title {
             payload["title"] = title
         }
-
-        payload["extraFields"] = sanitizedExtras
 
         db.collection("posts").document(postID).updateData(payload) { error in
             if let error = error {
@@ -301,6 +297,109 @@ class PostService: ObservableObject {
 }
 
 private extension PostService {
+    func sanitizeExtraFields(_ extras: [String: String]) -> [String: String] {
+        guard !extras.isEmpty else { return [:] }
+
+        var normalized: [String: String] = [:]
+        for (key, value) in extras {
+            normalized[key] = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        var sanitized: [String: String] = [:]
+        let reservedKeys: Set<String> = [
+            "ingredients",
+            "aiNotes",
+            "aiVoiceTranscript",
+            "calorieEstimate",
+            "starRating",
+            "rating",
+            "stars",
+            "isFavorite",
+            "favorite"
+        ]
+
+        if let ingredientsValue = extras["ingredients"] ?? normalized["ingredients"] {
+            let items = sanitizeIngredients(ingredientsValue)
+            if !items.isEmpty {
+                sanitized["ingredients"] = items.joined(separator: "\n")
+            }
+        }
+
+        if let notes = normalized["aiNotes"], !notes.isEmpty {
+            sanitized["aiNotes"] = notes
+        }
+
+        if let transcript = normalized["aiVoiceTranscript"], !transcript.isEmpty {
+            sanitized["aiVoiceTranscript"] = transcript
+        }
+
+        if let calories = sanitizeCalories(extras["calorieEstimate"] ?? normalized["calorieEstimate"]) {
+            sanitized["calorieEstimate"] = calories
+        }
+
+        if let ratingValue = sanitizedRating(from: extras["starRating"] ?? extras["rating"] ?? extras["stars"]) {
+            sanitized["starRating"] = ratingValue
+        }
+
+        if let isFavorite = sanitizedFavorite(from: extras["isFavorite"] ?? extras["favorite"]), isFavorite {
+            sanitized["isFavorite"] = "true"
+        }
+
+        for (key, value) in normalized where !value.isEmpty {
+            if sanitized.keys.contains(key) { continue }
+            if reservedKeys.contains(key) { continue }
+            sanitized[key] = value
+        }
+
+        return sanitized
+    }
+
+    func sanitizeCalories(_ rawValue: String?) -> String? {
+        guard let rawValue = rawValue else { return nil }
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let components = trimmed.components(separatedBy: CharacterSet.decimalDigits.inverted).filter { !$0.isEmpty }
+        guard let first = components.first else { return nil }
+        return first
+    }
+
+    func sanitizedRating(from rawValue: String?) -> String? {
+        guard let rawValue = rawValue else { return nil }
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let normalized = trimmed.replacingOccurrences(of: ",", with: ".")
+        if let value = Double(normalized) {
+            let clamped = max(0, min(value, 5))
+            return clamped > 0 ? String(format: "%.1f", clamped) : nil
+        }
+
+        let digits = normalized.compactMap { character -> Character? in
+            if character.isNumber || character == "." { return character }
+            return nil
+        }
+
+        guard let value = Double(String(digits)) else { return nil }
+        let clamped = max(0, min(value, 5))
+        return clamped > 0 ? String(format: "%.1f", clamped) : nil
+    }
+
+    func sanitizedFavorite(from rawValue: String?) -> Bool? {
+        guard let rawValue = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawValue.isEmpty else { return nil }
+
+        let normalized = rawValue.lowercased()
+        if ["true", "1", "yes", "y", "favorite", "fav"].contains(normalized) {
+            return true
+        }
+
+        if ["false", "0", "no", "n"].contains(normalized) {
+            return false
+        }
+
+        return nil
+    }
+
     func sanitizeIngredients(_ rawValue: String?) -> [String] {
         guard let rawValue = rawValue else { return [] }
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/yummr/ProfileView.swift
+++ b/yummr/ProfileView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import Firebase
 import FirebaseAuth
 import FirebaseFirestore
-import FirebaseFirestore
 import FirebaseStorage
 
 struct ProfileView: View {
@@ -30,8 +29,12 @@ struct ProfileView: View {
     @State private var selectedProfileImage: UIImage?
     @State private var selectedBannerImage: UIImage?
     @State private var showSettings = false
+    @State private var followerCount: Int = 0
+    @State private var followingCount: Int = 0
+    @State private var activeFriendList: FriendListView.Mode?
 
     private let db = Firestore.firestore()
+    @State private var friendListener: ListenerRegistration?
 
     private var resolvedUserID: String? {
         userID ?? auth.currentUser?.uid
@@ -116,7 +119,9 @@ struct ProfileView: View {
             loadProfileData()
             loadPosts()
             loadTaggedPosts()
+            startFriendListener()
         }
+        .onDisappear(perform: stopFriendListener)
         .sheet(isPresented: $showImagePicker) {
             ImagePicker(image: $selectedProfileImage)
                 .onDisappear { uploadProfileImage() }
@@ -128,6 +133,24 @@ struct ProfileView: View {
         .sheet(isPresented: $showSettings) {
             SettingsView()
                 .environmentObject(auth)
+        }
+        .sheet(item: $activeFriendList) { mode in
+            if let userID = resolvedUserID {
+                FriendListView(userID: userID, mode: mode)
+            } else {
+                NavigationView {
+                    VStack(spacing: 16) {
+                        Image(systemName: "person.crop.circle.badge.questionmark")
+                            .font(.largeTitle)
+                            .foregroundColor(.secondary)
+                        Text("User information is unavailable.")
+                            .multilineTextAlignment(.center)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding()
+                    .navigationTitle(mode.title)
+                }
+            }
         }
     }
 
@@ -239,20 +262,38 @@ struct ProfileView: View {
 
     private var statsSection: some View {
         HStack {
-            VStack {
-                Text("Followers")
-                    .font(.caption)
-                Text("\(profileUser?.followerCount ?? 0)")
-                    .bold()
+            Button {
+                activeFriendList = .followers
+            } label: {
+                VStack {
+                    Text("Followers")
+                        .font(.caption)
+                        .foregroundColor(.primary)
+                    Text("\(followerCount)")
+                        .bold()
+                        .foregroundColor(.primary)
+                }
+                .frame(maxWidth: .infinity)
             }
-            .frame(maxWidth: .infinity)
-            VStack {
-                Text("Following")
-                    .font(.caption)
-                Text("\(profileUser?.followingCount ?? 0)")
-                    .bold()
+            .buttonStyle(.plain)
+            .disabled(resolvedUserID == nil)
+
+            Button {
+                activeFriendList = .following
+            } label: {
+                VStack {
+                    Text("Following")
+                        .font(.caption)
+                        .foregroundColor(.primary)
+                    Text("\(followingCount)")
+                        .bold()
+                        .foregroundColor(.primary)
+                }
+                .frame(maxWidth: .infinity)
             }
-            .frame(maxWidth: .infinity)
+            .buttonStyle(.plain)
+            .disabled(resolvedUserID == nil)
+
             VStack {
                 Text("Posts")
                     .font(.caption)
@@ -271,6 +312,8 @@ struct ProfileView: View {
                 DispatchQueue.main.async {
                     self.profileUser = user
                     self.bio = user.bio ?? ""
+                    self.followerCount = user.followerCount ?? 0
+                    self.followingCount = user.followingCount ?? 0
                     if let profileURL = user.profileImageURL, let url = URL(string: profileURL) {
                         self.profileImageURL = url
                     }
@@ -307,7 +350,7 @@ struct ProfileView: View {
 
     private func updateBio() {
         guard let uid = resolvedUserID else { return }
-        db.collection("users").document(uid).updateData(["bio": bio])
+        db.collection("users").document(uid).setData(["bio": bio], merge: true)
         if isCurrentUser {
             self.profileUser?.bio = bio
         }
@@ -326,7 +369,7 @@ struct ProfileView: View {
                         DispatchQueue.main.async {
                             self.profileImageURL = url
                         }
-                        db.collection("users").document(uid).updateData(["profileImageURL": url.absoluteString])
+                        db.collection("users").document(uid).setData(["profileImageURL": url.absoluteString], merge: true)
                     }
                 }
             }
@@ -346,11 +389,27 @@ struct ProfileView: View {
                         DispatchQueue.main.async {
                             self.bannerImageURL = url
                         }
-                        db.collection("users").document(uid).updateData(["bannerImageURL": url.absoluteString])
+                        db.collection("users").document(uid).setData(["bannerImageURL": url.absoluteString], merge: true)
                     }
                 }
             }
         }
+    }
+
+    private func startFriendListener() {
+        guard isCurrentUser, let uid = resolvedUserID else { return }
+        friendListener?.remove()
+        friendListener = FriendService.shared.observeFriendIDs(for: uid) { ids in
+            DispatchQueue.main.async {
+                self.followerCount = ids.count
+                self.followingCount = ids.count
+            }
+        }
+    }
+
+    private func stopFriendListener() {
+        friendListener?.remove()
+        friendListener = nil
     }
 }
 
@@ -376,5 +435,140 @@ private struct TagSection: View {
             }
         }
         .padding(.horizontal)
+    }
+}
+
+private struct FriendListView: View {
+    enum Mode: String, Identifiable {
+        case followers
+        case following
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .followers: return "Followers"
+            case .following: return "Following"
+            }
+        }
+
+        var emptyMessage: String {
+            switch self {
+            case .followers: return "No followers yet."
+            case .following: return "Not following anyone yet."
+            }
+        }
+    }
+
+    let userID: String
+    let mode: Mode
+
+    @State private var isLoading = true
+    @State private var users: [AppUser] = []
+    @State private var errorMessage: String?
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationView {
+            Group {
+                if let errorMessage {
+                    VStack(spacing: 12) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .font(.largeTitle)
+                            .foregroundColor(.orange)
+                        Text(errorMessage)
+                            .multilineTextAlignment(.center)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding()
+                } else if isLoading {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                } else if users.isEmpty {
+                    VStack(spacing: 12) {
+                        Image(systemName: "person.crop.circle.badge.questionmark")
+                            .font(.largeTitle)
+                            .foregroundColor(.secondary)
+                        Text(mode.emptyMessage)
+                            .multilineTextAlignment(.center)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding()
+                } else {
+                    List {
+                        ForEach(users.indices, id: \.self) { index in
+                            let user = users[index]
+                            NavigationLink(destination: ProfileView(userID: user.id ?? "")) {
+                                HStack(spacing: 12) {
+                                    CachedWebImage(url: URL(string: user.profileImageURL ?? "")) {
+                                        Circle()
+                                            .fill(Color.gray.opacity(0.2))
+                                            .frame(width: 44, height: 44)
+                                    }
+                                    .aspectRatio(contentMode: .fill)
+                                    .frame(width: 44, height: 44)
+                                    .clipShape(Circle())
+
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(user.displayName)
+                                            .font(.body)
+                                        Text("@\(user.handle)")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                    }
+                                }
+                                .padding(.vertical, 4)
+                            }
+                        }
+                    }
+                    .listStyle(.insetGrouped)
+                }
+            }
+            .navigationTitle(mode.title)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .onAppear(perform: loadUsers)
+    }
+
+    private func loadUsers() {
+        guard !userID.isEmpty else {
+            errorMessage = "User information is unavailable."
+            isLoading = false
+            return
+        }
+
+        isLoading = true
+        errorMessage = nil
+
+        FriendService.shared.fetchFriendIDs(for: userID) { result in
+            switch result {
+            case .failure(let error):
+                DispatchQueue.main.async {
+                    self.errorMessage = error.localizedDescription
+                    self.isLoading = false
+                }
+            case .success(let ids):
+                guard !ids.isEmpty else {
+                    DispatchQueue.main.async {
+                        self.users = []
+                        self.isLoading = false
+                    }
+                    return
+                }
+
+                UserService.shared.fetchUsers(withIDs: ids) { users in
+                    let sorted = users.sorted {
+                        ($0.displayName.lowercased(), $0.handle.lowercased())
+                            < ($1.displayName.lowercased(), $1.handle.lowercased())
+                    }
+                    self.users = sorted
+                    self.isLoading = false
+                }
+            }
+        }
     }
 }

--- a/yummr/SecretsService.swift
+++ b/yummr/SecretsService.swift
@@ -1,0 +1,67 @@
+import Foundation
+import FirebaseFirestore
+
+final class SecretsService: ObservableObject {
+    static let shared = SecretsService()
+
+    private let db = Firestore.firestore()
+    private lazy var sharedSecretsReference = db.collection("appConfig").document("publicSecrets")
+    private let keychainKey = "ai.gemini.apiKey"
+    private var cachedGeminiKey: String?
+
+    private init() {
+        if let existing = KeychainHelper.load(keychainKey)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !existing.isEmpty {
+            cachedGeminiKey = existing
+        }
+    }
+
+    func cachedGeminiAPIKey() -> String? {
+        if let cached = cachedGeminiKey, !cached.isEmpty {
+            return cached
+        }
+
+        if let stored = KeychainHelper.load(keychainKey)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !stored.isEmpty {
+            cachedGeminiKey = stored
+            return stored
+        }
+
+        return nil
+    }
+
+    func resolveSharedGeminiAPIKey() async throws -> String? {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.sharedSecretsReference.getDocument { snapshot, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+
+                guard let data = snapshot?.data(),
+                      let rawKey = data["geminiAPIKey"] as? String,
+                      let sanitized = self.sanitizedGeminiKey(from: rawKey) else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                self.cacheGeminiAPIKey(sanitized)
+                continuation.resume(returning: sanitized)
+            }
+        }
+    }
+
+    func cacheGeminiAPIKey(_ key: String) {
+        guard let sanitized = sanitizedGeminiKey(from: key) else { return }
+        KeychainHelper.save(keychainKey, sanitized)
+        cachedGeminiKey = sanitized
+    }
+
+    private func sanitizedGeminiKey(from rawValue: String?) -> String? {
+        guard let trimmed = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/yummr/SettingsView.swift
+++ b/yummr/SettingsView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 import FirebaseAuth
-import FirebaseFirestore
+import FirebaseCore
 
 struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
@@ -21,6 +21,9 @@ struct SettingsView: View {
 
     @State private var notificationSettings = AppUser.NotificationSettings.default
     @State private var privacySettings = AppUser.PrivacySettings.default
+    @State private var geminiAPIKey: String = ""
+    @State private var geminiStatusMessage: String?
+    @State private var isLoadingGeminiKey = false
 
     var body: some View {
         NavigationStack {
@@ -29,6 +32,7 @@ struct SettingsView: View {
                 phoneSection
                 notificationsSection
                 privacySection
+                aiSection
                 destructiveSection
             }
             .navigationTitle("Settings")
@@ -37,7 +41,10 @@ struct SettingsView: View {
                     Button("Done") { dismiss() }
                 }
             }
-            .onAppear(perform: loadUser)
+            .onAppear {
+                loadUser()
+                loadGeminiKey()
+            }
         }
     }
 
@@ -69,6 +76,12 @@ struct SettingsView: View {
             TextField("Phone number", text: $phoneNumber)
                 .keyboardType(.phonePad)
 
+            if let warning = phoneVerificationWarning {
+                Text(warning)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
             Button {
                 sendVerificationCode()
             } label: {
@@ -78,7 +91,7 @@ struct SettingsView: View {
                     Text("Send verification code")
                 }
             }
-            .disabled(phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSendingCode)
+            .disabled(phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSendingCode || phoneVerificationWarning != nil)
 
             if verificationID != nil {
                 TextField("Verification code", text: $verificationCode)
@@ -93,7 +106,7 @@ struct SettingsView: View {
                         Text("Verify & save")
                     }
                 }
-                .disabled(verificationCode.count < 4 || isVerifyingCode)
+                .disabled(verificationCode.count < 4 || isVerifyingCode || phoneVerificationWarning != nil)
             }
 
             if let phoneStatusMessage {
@@ -160,6 +173,36 @@ struct SettingsView: View {
         }
     }
 
+    private var aiSection: some View {
+        Section("AI Drafting") {
+            if isLoadingGeminiKey {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                LabeledContent("Shared Gemini key") {
+                    Text(maskedGeminiKey)
+                        .monospaced()
+                        .foregroundColor(geminiAPIKey.isEmpty ? .secondary : .primary)
+                }
+            }
+
+            if let message = geminiStatusMessage {
+                Text(message)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Button("Reload shared key") {
+                loadGeminiKey(force: true)
+            }
+            .disabled(isLoadingGeminiKey)
+
+            Text("The Gemini API key is managed centrally for all users. Update it in Firestore if you need to rotate the shared credential.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
     private var destructiveSection: some View {
         Section {
             Button(role: .destructive) {
@@ -213,8 +256,122 @@ struct SettingsView: View {
         }
     }
 
+    private func loadGeminiKey(force: Bool = false) {
+        if !force, let cached = SecretsService.shared.cachedGeminiAPIKey() {
+            geminiAPIKey = cached
+            geminiStatusMessage = "Using cached Gemini API key."
+            return
+        }
+
+        isLoadingGeminiKey = true
+        geminiStatusMessage = nil
+
+        Task {
+            do {
+                if let remote = try await SecretsService.shared.resolveSharedGeminiAPIKey() {
+                    await MainActor.run {
+                        geminiAPIKey = remote
+                        geminiStatusMessage = "Loaded the shared Gemini API key."
+                        isLoadingGeminiKey = false
+                    }
+                } else {
+                    let fallback = fallbackGeminiKey()
+                    await MainActor.run {
+                        if let fallback = fallback {
+                            geminiAPIKey = fallback
+                            geminiStatusMessage = "Using a fallback Gemini key until the shared key is configured."
+                        } else {
+                            geminiAPIKey = ""
+                            geminiStatusMessage = "No shared Gemini API key is configured yet."
+                        }
+                        isLoadingGeminiKey = false
+                    }
+                }
+            } catch {
+                let fallback = fallbackGeminiKey()
+                await MainActor.run {
+                    if let fallback = fallback {
+                        geminiAPIKey = fallback
+                        geminiStatusMessage = "Using a fallback Gemini key. Couldn't refresh the shared key: \(error.localizedDescription)"
+                    } else {
+                        geminiAPIKey = ""
+                        geminiStatusMessage = "Couldn't refresh the shared key: \(error.localizedDescription)"
+                    }
+                    isLoadingGeminiKey = false
+                }
+            }
+        }
+    }
+
+    private func fallbackGeminiKey() -> String? {
+        if let cached = SecretsService.shared.cachedGeminiAPIKey() {
+            return cached
+        }
+
+        if let secretsURL = Bundle.main.url(forResource: "GeminiSecrets", withExtension: "plist"),
+           let secrets = NSDictionary(contentsOf: secretsURL),
+           let bundledKey = secrets["GeminiAPIKey"] as? String,
+           let sanitized = sanitizedGeminiKey(from: bundledKey) {
+            return sanitized
+        }
+
+        if let environmentKey = ProcessInfo.processInfo.environment["GEMINI_API_KEY"],
+           let sanitized = sanitizedGeminiKey(from: environmentKey) {
+            return sanitized
+        }
+
+        return nil
+    }
+
+    private func sanitizedGeminiKey(from raw: String?) -> String? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+
+        SecretsService.shared.cacheGeminiAPIKey(trimmed)
+        return trimmed
+    }
+
+    private var maskedGeminiKey: String {
+        guard !geminiAPIKey.isEmpty else { return "Not configured" }
+        let prefixCount = min(4, geminiAPIKey.count)
+        let prefix = String(geminiAPIKey.prefix(prefixCount))
+        let maskCount = max(4, geminiAPIKey.count - prefixCount)
+        let mask = String(repeating: "•", count: maskCount)
+        return prefixCount == geminiAPIKey.count ? mask : prefix + mask
+    }
+
+    private var phoneVerificationWarning: String? {
+        guard let firebaseApp = FirebaseApp.app() else {
+            return "Phone verification is unavailable because Firebase isn't configured."
+        }
+
+        guard let bundleID = Bundle.main.bundleIdentifier else {
+            return "Phone verification is unavailable in this build."
+        }
+
+        if let configuredBundleID = firebaseApp.options.bundleID,
+           configuredBundleID != bundleID {
+            return "Phone verification is disabled in this build. Update GoogleService-Info.plist to match the app's bundle identifier."
+        }
+
+        return nil
+    }
+
     private func sendVerificationCode() {
         guard !phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+
+        if let warning = phoneVerificationWarning {
+            phoneStatusMessage = warning
+            return
+        }
+
+        guard Auth.auth().currentUser != nil else {
+            phoneStatusMessage = "You need to be signed in to verify a phone number."
+            return
+        }
+
         isSendingCode = true
         phoneStatusMessage = "Sending…"
         PhoneAuthProvider.provider().verifyPhoneNumber(phoneNumber, uiDelegate: nil) { verificationID, error in
@@ -232,6 +389,17 @@ struct SettingsView: View {
 
     private func verifyCode() {
         guard let verificationID else { return }
+
+        if let warning = phoneVerificationWarning {
+            phoneStatusMessage = warning
+            return
+        }
+
+        guard Auth.auth().currentUser != nil else {
+            phoneStatusMessage = "You need to be signed in to verify a phone number."
+            return
+        }
+
         isVerifyingCode = true
         phoneStatusMessage = "Verifying…"
         let credential = PhoneAuthProvider.provider().credential(withVerificationID: verificationID,

--- a/yummr/UserService.swift
+++ b/yummr/UserService.swift
@@ -7,12 +7,115 @@
 
 
 import Foundation
+import FirebaseAuth
 import FirebaseFirestore
 import FirebaseFirestoreSwift
 
 final class UserService: ObservableObject {
     static let shared = UserService()
     private let db = Firestore.firestore()
+
+    func ensureUserDocument(for user: User,
+                             displayName overrideDisplayName: String? = nil,
+                             completion: ((Error?) -> Void)? = nil) {
+        let userRef = db.collection("users").document(user.uid)
+
+        userRef.getDocument { snapshot, error in
+            if let error = error {
+                completion?(error)
+                return
+            }
+
+            let existingData = snapshot?.data() ?? [:]
+
+            let rawDisplayName = overrideDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+                .flatMap { $0.isEmpty ? nil : $0 }
+                ?? user.displayName
+                ?? user.email
+                ?? "New Chef"
+
+            let normalizedHandle = HandleFormatter.normalizedHandle(from: rawDisplayName)
+            let sanitizedHandle = normalizedHandle.hasPrefix("@")
+                ? String(normalizedHandle.dropFirst())
+                : normalizedHandle
+
+            var payload: [String: Any] = [:]
+
+            if ((existingData["displayName"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true) {
+                payload["displayName"] = rawDisplayName
+            }
+
+            if ((existingData["handle"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true) {
+                payload["handle"] = sanitizedHandle
+            }
+
+            if existingData["notificationSettings"] == nil {
+                payload["notificationSettings"] = [
+                    "likes": true,
+                    "comments": true,
+                    "friendRequests": true,
+                    "friendPosts": true,
+                    "mutedUserIDs": []
+                ]
+            }
+
+            if existingData["privacySettings"] == nil {
+                payload["privacySettings"] = [
+                    "isPrivateAccount": false,
+                    "allowContactDiscovery": true
+                ]
+            }
+
+            if existingData["followerCount"] == nil {
+                payload["followerCount"] = 0
+            }
+
+            if existingData["followingCount"] == nil {
+                payload["followingCount"] = 0
+            }
+
+            if existingData["topFoods"] == nil {
+                payload["topFoods"] = []
+            }
+
+            if existingData["healthMetrics"] == nil {
+                payload["healthMetrics"] = [:]
+            }
+
+            if existingData["bio"] == nil {
+                payload["bio"] = ""
+            }
+
+            if existingData["profileImageURL"] == nil, let url = user.photoURL?.absoluteString {
+                payload["profileImageURL"] = url
+            }
+
+            if existingData["phoneNumber"] == nil, let phone = user.phoneNumber, !phone.isEmpty {
+                payload["phoneNumber"] = phone
+            }
+
+            if existingData["friendIDs"] == nil {
+                payload["friendIDs"] = []
+            }
+
+            if existingData["pendingFriendRequestIDs"] == nil {
+                payload["pendingFriendRequestIDs"] = []
+            }
+
+            if payload.isEmpty {
+                SavedService.shared.ensureDefaultCollection(for: user.uid)
+                completion?(nil)
+                return
+            }
+
+            userRef.setData(payload, merge: true) { error in
+                if error == nil {
+                    SavedService.shared.ensureDefaultCollection(for: user.uid)
+                }
+                completion?(error)
+            }
+        }
+    }
 
     func searchUsers(matching query: String,
                      limit: Int = 20,
@@ -24,6 +127,14 @@ final class UserService: ObservableObject {
             return
         }
 
+        let normalizedQuery: String
+        if trimmed.hasPrefix("@") {
+            let stripped = String(trimmed.drop(while: { $0 == "@" }))
+            normalizedQuery = stripped.isEmpty ? trimmed : stripped
+        } else {
+            normalizedQuery = trimmed
+        }
+
         db.collection("users")
             .limit(to: max(limit * 3, 25))
             .getDocuments { snapshot, error in
@@ -32,7 +143,7 @@ final class UserService: ObservableObject {
                     return
                 }
 
-                let lowercasedQuery = trimmed.lowercased()
+                let lowercasedQuery = normalizedQuery.lowercased()
                 let users: [AppUser] = documents.compactMap { try? $0.data(as: AppUser.self) }
                     .sorted { ($0.displayName.lowercased(), $0.handle.lowercased()) < ($1.displayName.lowercased(), $1.handle.lowercased()) }
                     .filter { user in


### PR DESCRIPTION
## Summary
- allow the AI recipe flow to fall back to cached, bundled, or environment Gemini API keys when Firestore is unavailable
- update the settings Gemini section to surface fallback keys and reuse cached values when the shared secret is missing or fetches fail
- provide a clear alert when the device cannot present the camera picker so users know to select from their library instead

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f1a62c0ed48323933ce45b68a11302