### PR TITLE
Improve profile interactions and post presentation

### DIFF
--- a/yummr/AIDraftWorkshopView.swift
+++ b/yummr/AIDraftWorkshopView.swift
@@ -310,15 +310,6 @@ struct AIDraftWorkshopView: View {
 
     @MainActor
     private func applyAIDraft(_ draft: AIRecipeDraft) {
-        if let newTitle = draft.title?.trimmingCharacters(in: .whitespacesAndNewlines), !newTitle.isEmpty {
-            title = newTitle
-        }
-
-        let summarySource = draft.summary ?? draft.description
-        if let newSummary = summarySource?.trimmingCharacters(in: .whitespacesAndNewlines), !newSummary.isEmpty {
-            description = newSummary
-        }
-
         if let newIngredients = draft.ingredients?.map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) }).filter({ !$0.isEmpty }),
            !newIngredients.isEmpty {
             ingredients = newIngredients

--- a/yummr/FriendService.swift
+++ b/yummr/FriendService.swift
@@ -126,6 +126,68 @@ final class FriendService: ObservableObject {
         }
     }
 
+    func createFriendship(with targetUID: String, completion: ((Error?) -> Void)? = nil) {
+        guard let currentUID = Auth.auth().currentUser?.uid else {
+            completion?(NSError(domain: "Auth", code: -1, userInfo: [NSLocalizedDescriptionKey: "Not signed in"]))
+            return
+        }
+
+        guard currentUID != targetUID else {
+            completion?(nil)
+            return
+        }
+
+        let friendData = [
+            "createdAt": FieldValue.serverTimestamp()
+        ]
+
+        let batch = db.batch()
+        let currentFriendRef = db.collection("users").document(currentUID)
+            .collection("friends").document(targetUID)
+        let targetFriendRef = db.collection("users").document(targetUID)
+            .collection("friends").document(currentUID)
+
+        batch.setData(friendData, forDocument: currentFriendRef, merge: true)
+        batch.setData(friendData, forDocument: targetFriendRef, merge: true)
+
+        batch.commit { error in
+            if error == nil {
+                self.incrementFriendCounts(for: [currentUID, targetUID], delta: 1)
+            }
+            completion?(error)
+        }
+    }
+
+    func isFriends(with targetUID: String, completion: @escaping (Bool) -> Void) {
+        guard let currentUID = Auth.auth().currentUser?.uid else {
+            completion(false)
+            return
+        }
+
+        db.collection("users")
+            .document(currentUID)
+            .collection("friends")
+            .document(targetUID)
+            .getDocument { snapshot, _ in
+                completion(snapshot?.exists ?? false)
+            }
+    }
+
+    func hasPendingRequest(to targetUID: String, completion: @escaping (Bool) -> Void) {
+        guard let currentUID = Auth.auth().currentUser?.uid else {
+            completion(false)
+            return
+        }
+
+        db.collection("users")
+            .document(targetUID)
+            .collection("friendRequests")
+            .document(currentUID)
+            .getDocument { snapshot, _ in
+                completion(snapshot?.exists ?? false)
+            }
+    }
+
     private func incrementFriendCounts(for uids: [String], delta: Int64) {
         guard delta != 0 else { return }
         let batch = db.batch()

--- a/yummr/Post+Metadata.swift
+++ b/yummr/Post+Metadata.swift
@@ -1,6 +1,19 @@
 import Foundation
 
 extension Post {
+    /// Returns a stable identifier for the post even when the Firestore document ID is unavailable.
+    var stableIdentifier: String {
+        if let id = id, !id.isEmpty {
+            return id
+        }
+
+        let sanitizedTitle = title
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\n", with: " ")
+        let timestampComponent = String(Int(timestamp.timeIntervalSince1970 * 1000))
+        return "\(sanitizedTitle)-\(timestampComponent)"
+    }
+
     var starRating: Double? {
         parseDouble(forKeys: ["rating", "starRating", "stars"])
     }

--- a/yummr/Post+Metadata.swift
+++ b/yummr/Post+Metadata.swift
@@ -41,7 +41,7 @@ extension Post {
         guard let recipe else { return [] }
         return recipe
             .components(separatedBy: CharacterSet.newlines)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .map { sanitizeInstruction($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
             .filter { !$0.isEmpty }
     }
 
@@ -66,5 +66,16 @@ extension Post {
             .components(separatedBy: CharacterSet(charactersIn: ",\n•"))
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
+    }
+
+    private func sanitizeInstruction(_ step: String) -> String {
+        guard let opening = step.firstIndex(of: "<"),
+              let closing = step[opening...].firstIndex(of: ">"),
+              opening == step.startIndex else {
+            return step
+        }
+
+        let cleaned = step[step.index(after: closing)...].trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned.isEmpty ? step : cleaned
     }
 }

--- a/yummr/PostCard.swift
+++ b/yummr/PostCard.swift
@@ -15,6 +15,8 @@ struct PostCard: View {
     @State private var previewComments: [Comment] = []
     @State private var isSaved = false
     @State private var author: AppUser?
+    @State private var isShareSheetPresented = false
+    @State private var shareItems: [Any] = []
 
     init(post: Post) {
         self.post = post
@@ -23,17 +25,10 @@ struct PostCard: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 16) {
             header
 
             titleRow
-
-            if let caption = captionText {
-                Text(caption)
-                    .appTextStyle(.body)
-                    .foregroundColor(Color(.secondaryLabel))
-                    .lineSpacing(2)
-            }
 
             tabbedImages
 
@@ -56,7 +51,8 @@ struct PostCard: View {
                 commentPreview
             }
         }
-        .padding(16)
+        .padding(.vertical, 16)
+        .padding(.horizontal, 16)
         .background(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(Color(.secondarySystemBackground))
@@ -71,6 +67,9 @@ struct PostCard: View {
             checkSaveState()
             fetchAuthor()
         }
+        .sheet(isPresented: $isShareSheetPresented) {
+            ShareSheet(activityItems: shareItems)
+        }
         .sheet(isPresented: $showAllComments, onDismiss: {
             fetchCommentsPreview()
         }) {
@@ -79,16 +78,16 @@ struct PostCard: View {
     }
 
     private var header: some View {
-        HStack(alignment: .top, spacing: 12) {
+        HStack(alignment: .center, spacing: 12) {
             NavigationLink(destination: ProfileView(userID: post.authorID)) {
                 avatarView
             }
             .buttonStyle(.plain)
 
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: 2) {
                 NavigationLink(destination: ProfileView(userID: post.authorID)) {
                     Text(primaryAuthorName)
-                        .appTextStyle(.body, weight: .semibold)
+                        .appTextStyle(.callout, weight: .semibold)
                         .foregroundColor(.primary)
                         .lineLimit(1)
                 }
@@ -104,7 +103,7 @@ struct PostCard: View {
 
             Menu {
                 Button("Share") {
-                    // TODO: share implementation
+                    prepareShareSheet()
                 }
                 Button("Report", role: .destructive) {
                     // TODO: report implementation
@@ -120,22 +119,26 @@ struct PostCard: View {
     }
 
     private var titleRow: some View {
-        HStack(alignment: .center, spacing: 8) {
-            Text(post.title)
-                .appTextStyle(.title3, weight: .semibold)
-                .foregroundColor(.primary)
-                .multilineTextAlignment(.leading)
-                .lineLimit(2)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(post.title)
+                    .appTextStyle(.headline, weight: .semibold)
+                    .foregroundColor(.primary)
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(2)
 
-            if let rating = post.starRating {
-                StarRatingView(rating: rating)
+                Spacer()
+
+                if let rating = post.starRating {
+                    StarRatingView(rating: rating)
+                }
             }
 
-            if post.isFavorited {
-                Image(systemName: "star.fill")
-                    .foregroundColor(.yellow)
-                    .font(.caption)
-                    .accessibilityLabel("Favorited")
+            if let caption = captionText {
+                Text(caption)
+                    .appTextStyle(.subheadline)
+                    .foregroundColor(Color(.secondaryLabel))
+                    .lineLimit(2)
             }
         }
     }
@@ -258,14 +261,24 @@ struct PostCard: View {
                         }
                     }
                 }
-                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .padding(.horizontal, -16)
                 .padding(.bottom, 4)
                 .tag(item.offset)
             }
         }
         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .automatic))
         .frame(maxWidth: .infinity)
-        .aspectRatio(4.0 / 5.0, contentMode: .fit)
+        .aspectRatio(1.0, contentMode: .fit)
+        .overlay(alignment: .topTrailing) {
+            if post.isFavorited {
+                Image(systemName: "bookmark.circle.fill")
+                    .font(.system(size: 26, weight: .semibold))
+                    .foregroundColor(.yellow)
+                    .padding(.trailing, 4)
+                    .padding(.top, 4)
+            }
+        }
     }
 
     private func tagOverlay(tag: Post.PhotoTag, geometry: GeometryProxy) -> some View {
@@ -364,6 +377,19 @@ struct PostCard: View {
                 self.author = user
             }
         }
+    }
+
+    private func prepareShareSheet() {
+        var items: [Any] = [post.title]
+        let trimmedDescription = post.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedDescription.isEmpty {
+            items.append(trimmedDescription)
+        }
+        if let urlString = post.imageURLs.first, let url = URL(string: urlString) {
+            items.append(url)
+        }
+        shareItems = items
+        isShareSheetPresented = !items.isEmpty
     }
 
     private var primaryAuthorName: String {

--- a/yummr/ProfileView.swift
+++ b/yummr/ProfileView.swift
@@ -32,6 +32,10 @@ struct ProfileView: View {
     @State private var followerCount: Int = 0
     @State private var followingCount: Int = 0
     @State private var activeFriendList: FriendListView.Mode?
+    @State private var isFollowingProfile = false
+    @State private var isProcessingFollowAction = false
+    @State private var selectedPostForFeed: Post?
+    @State private var isShowingUserFeed = false
 
     private let db = Firestore.firestore()
     @State private var friendListener: ListenerRegistration?
@@ -75,6 +79,10 @@ struct ProfileView: View {
                         .padding(.horizontal)
                     }
 
+                    if selectedTab == .posts && !pinnedFavoritePosts.isEmpty {
+                        favoriteRecipesSection
+                    }
+
                     Picker("Profile Content", selection: $selectedTab) {
                         ForEach(ProfileTab.allCases) { tab in
                             Text(tab.rawValue).tag(tab)
@@ -83,21 +91,7 @@ struct ProfileView: View {
                     .pickerStyle(.segmented)
                     .padding(.horizontal)
 
-                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
-                        ForEach(currentPosts) { post in
-                            NavigationLink(destination: PostDetailView(post: post)) {
-                                CachedWebImage(url: URL(string: post.imageURLs.first ?? "")) {
-                                    ProgressView()
-                                }
-                                .aspectRatio(contentMode: .fill)
-                                .frame(height: 140)
-                                .clipped()
-                                .cornerRadius(12)
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
-                    .padding(.horizontal)
+                    profilePostGrid
                 }
                 .padding(.bottom, 24)
             }
@@ -120,8 +114,15 @@ struct ProfileView: View {
             loadPosts()
             loadTaggedPosts()
             startFriendListener()
+            refreshFriendshipState()
         }
         .onDisappear(perform: stopFriendListener)
+        .onChange(of: userID) { _ in
+            loadProfileData()
+            loadPosts()
+            loadTaggedPosts()
+            refreshFriendshipState()
+        }
         .sheet(isPresented: $showImagePicker) {
             ImagePicker(image: $selectedProfileImage)
                 .onDisappear { uploadProfileImage() }
@@ -159,6 +160,10 @@ struct ProfileView: View {
         case .posts: return userPosts
         case .tagged: return taggedPosts
         }
+    }
+
+    private var pinnedFavoritePosts: [Post] {
+        userPosts.filter { $0.isFavorited }
     }
 
     private var bannerSection: some View {
@@ -254,6 +259,8 @@ struct ProfileView: View {
                 if isCurrentUser {
                     Button("Edit Bio") { isEditingBio = true }
                         .font(.caption)
+                } else {
+                    followActionButton
                 }
             }
         }
@@ -305,6 +312,112 @@ struct ProfileView: View {
         .padding()
     }
 
+    private var profilePostGrid: some View {
+        ZStack {
+            Color.white
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 1), count: 3), spacing: 1) {
+                ForEach(currentPosts) { post in
+                    Button {
+                        selectedPostForFeed = post
+                        isShowingUserFeed = true
+                    } label: {
+                        GeometryReader { geometry in
+                            CachedWebImage(url: URL(string: post.imageURLs.first ?? "")) {
+                                Color.gray.opacity(0.2)
+                            }
+                            .scaledToFill()
+                            .frame(width: geometry.size.width, height: geometry.size.width)
+                            .clipped()
+                        }
+                        .aspectRatio(1, contentMode: .fit)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            userFeedNavigationLink
+                .hidden()
+        }
+        .padding(.horizontal, 1)
+    }
+
+    private var favoriteRecipesSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Favorite Recipes")
+                    .font(.headline)
+                Spacer()
+                Text("Pinned")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    ForEach(pinnedFavoritePosts) { post in
+                        NavigationLink(destination: PostDetailView(post: post)) {
+                            CachedWebImage(url: URL(string: post.imageURLs.first ?? "")) {
+                                Color.gray.opacity(0.2)
+                            }
+                            .frame(width: 140, height: 180)
+                            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+        .padding(.horizontal)
+    }
+
+    private var followActionButton: some View {
+        Button {
+            guard !isProcessingFollowAction else { return }
+            if isFollowingProfile {
+                unfollowProfile()
+            } else {
+                followProfile()
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: isFollowingProfile ? "person.crop.circle.badge.minus" : "person.crop.circle.badge.plus")
+                Text(isFollowingProfile ? "Unfollow" : "Follow")
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+        .disabled(isProcessingFollowAction || resolvedUserID == nil)
+        .padding(.top, 8)
+    }
+
+    @ViewBuilder
+    private var userFeedNavigationLink: some View {
+        if let userID = resolvedUserID {
+            NavigationLink(
+                destination: UserPostsFeedView(
+                    authorID: userID,
+                    authorName: profileUser?.displayName,
+                    initialPostID: selectedPostForFeed?.id
+                ),
+                isActive: Binding(
+                    get: { isShowingUserFeed },
+                    set: { newValue in
+                        if !newValue {
+                            selectedPostForFeed = nil
+                        }
+                        isShowingUserFeed = newValue
+                    }
+                )
+            ) {
+                EmptyView()
+            }
+        } else {
+            EmptyView()
+        }
+    }
+
     private func loadProfileData() {
         guard let uid = resolvedUserID else { return }
         db.collection("users").document(uid).getDocument { snapshot, _ in
@@ -344,6 +457,15 @@ struct ProfileView: View {
         PostService.shared.fetchTaggedPosts(for: uid) { posts in
             DispatchQueue.main.async {
                 self.taggedPosts = posts.sorted { $0.timestamp > $1.timestamp }
+            }
+        }
+    }
+
+    private func refreshFriendshipState() {
+        guard !isCurrentUser, let uid = resolvedUserID else { return }
+        FriendService.shared.isFriends(with: uid) { isFriend in
+            DispatchQueue.main.async {
+                self.isFollowingProfile = isFriend
             }
         }
     }
@@ -410,6 +532,34 @@ struct ProfileView: View {
     private func stopFriendListener() {
         friendListener?.remove()
         friendListener = nil
+    }
+
+    private func followProfile() {
+        guard let uid = resolvedUserID else { return }
+        isProcessingFollowAction = true
+        FriendService.shared.createFriendship(with: uid) { error in
+            DispatchQueue.main.async {
+                self.isProcessingFollowAction = false
+                if error == nil {
+                    self.isFollowingProfile = true
+                    self.loadProfileData()
+                }
+            }
+        }
+    }
+
+    private func unfollowProfile() {
+        guard let uid = resolvedUserID else { return }
+        isProcessingFollowAction = true
+        FriendService.shared.removeFriend(uid) { error in
+            DispatchQueue.main.async {
+                self.isProcessingFollowAction = false
+                if error == nil {
+                    self.isFollowingProfile = false
+                    self.loadProfileData()
+                }
+            }
+        }
     }
 }
 

--- a/yummr/ProfileView.swift
+++ b/yummr/ProfileView.swift
@@ -34,7 +34,7 @@ struct ProfileView: View {
     @State private var activeFriendList: FriendListView.Mode?
     @State private var isFollowingProfile = false
     @State private var isProcessingFollowAction = false
-    @State private var selectedPostForFeed: Post?
+    @State private var selectedPostID: String?
     @State private var isShowingUserFeed = false
 
     private let db = Firestore.firestore()
@@ -318,7 +318,7 @@ struct ProfileView: View {
             LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 1), count: 3), spacing: 1) {
                 ForEach(currentPosts) { post in
                     Button {
-                        selectedPostForFeed = post
+                        selectedPostID = post.stableIdentifier
                         isShowingUserFeed = true
                     } label: {
                         GeometryReader { geometry in
@@ -399,13 +399,13 @@ struct ProfileView: View {
                 destination: UserPostsFeedView(
                     authorID: userID,
                     authorName: profileUser?.displayName,
-                    initialPostID: selectedPostForFeed?.id
+                    initialPostID: selectedPostID
                 ),
                 isActive: Binding(
                     get: { isShowingUserFeed },
                     set: { newValue in
                         if !newValue {
-                            selectedPostForFeed = nil
+                            selectedPostID = nil
                         }
                         isShowingUserFeed = newValue
                     }

--- a/yummr/RootView.swift
+++ b/yummr/RootView.swift
@@ -9,32 +9,75 @@ import SwiftUI
 
 
 struct RootView: View {
+    private enum Tab: Hashable {
+        case feed, search, create, saved, profile
+    }
+
     @StateObject var auth = AuthService()
     @State private var searchFilter: SearchView.SortFilter = .trending
+    @State private var selectedTab: Tab = .feed
+    @State private var feedViewID = UUID()
+    @State private var searchViewID = UUID()
+    @State private var createViewID = UUID()
+    @State private var savedViewID = UUID()
+    @State private var profileViewID = UUID()
 
     var body: some View {
         Group {
             if auth.currentUser != nil {
-                TabView {
+                TabView(selection: Binding(
+                    get: { selectedTab },
+                    set: { newValue in
+                        if selectedTab == newValue {
+                            resetView(for: newValue)
+                        }
+                        selectedTab = newValue
+                    }
+                )) {
                     FeedView()
+                        .id(feedViewID)
                         .tabItem { Label("Feed",    systemImage: "list.bullet") }
+                        .tag(Tab.feed)
 
                     SearchView(selectedFilter: $searchFilter)
+                        .id(searchViewID)
                         .tabItem { Label("Search",  systemImage: "magnifyingglass") }
+                        .tag(Tab.search)
 
                     CreatePostView()
+                        .id(createViewID)
                         .tabItem { Label("Create",  systemImage: "plus.circle") }
+                        .tag(Tab.create)
 
                     SavedCollectionsView()
+                        .id(savedViewID)
                         .tabItem { Label("Saved", systemImage: "bookmark") }
+                        .tag(Tab.saved)
 
                     ProfileView()
+                        .id(profileViewID)
                         .tabItem { Label("Profile", systemImage: "person.crop.circle") }
+                        .tag(Tab.profile)
                 }
             } else {
                 AuthView()
             }
         }
         .environmentObject(auth)
+    }
+
+    private func resetView(for tab: Tab) {
+        switch tab {
+        case .feed:
+            feedViewID = UUID()
+        case .search:
+            searchViewID = UUID()
+        case .create:
+            createViewID = UUID()
+        case .saved:
+            savedViewID = UUID()
+        case .profile:
+            profileViewID = UUID()
+        }
     }
 }

--- a/yummr/SearchView.swift
+++ b/yummr/SearchView.swift
@@ -197,7 +197,22 @@ struct SearchView: View {
                 HStack(spacing: 16) {
                     ForEach(contactSuggestions, id: \.handle) { user in
                         VStack(spacing: 8) {
-                            NavigationLink(destination: ProfileView(userID: user.id ?? "")) {
+                            if let id = user.id, !id.isEmpty {
+                                NavigationLink(destination: ProfileView(userID: id)) {
+                                    VStack {
+                                        CachedWebImage(url: URL(string: user.profileImageURL ?? "")) {
+                                            Circle().fill(Color.gray.opacity(0.3))
+                                                .frame(width: 64, height: 64)
+                                        }
+                                        .aspectRatio(contentMode: .fill)
+                                        .frame(width: 64, height: 64)
+                                        .clipShape(Circle())
+
+                                        Text(user.displayName)
+                                            .font(.caption)
+                                    }
+                                }
+                            } else {
                                 VStack {
                                     CachedWebImage(url: URL(string: user.profileImageURL ?? "")) {
                                         Circle().fill(Color.gray.opacity(0.3))
@@ -210,6 +225,7 @@ struct SearchView: View {
                                     Text(user.displayName)
                                         .font(.caption)
                                 }
+                                .opacity(0.6)
                             }
                             friendActionButton(for: user)
                                 .font(.caption)

--- a/yummr/ShareSheet.swift
+++ b/yummr/ShareSheet.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+import UIKit
+
+struct ShareSheet: UIViewControllerRepresentable {
+    var activityItems: [Any]
+    var applicationActivities: [UIActivity]? = nil
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: applicationActivities)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {
+        // No-op
+    }
+}

--- a/yummr/StarRatingView.swift
+++ b/yummr/StarRatingView.swift
@@ -4,14 +4,14 @@ struct StarRatingView: View {
     let rating: Double
 
     var body: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: 4) {
             ForEach(0..<5, id: \.self) { index in
                 Image(systemName: symbol(for: index))
                     .foregroundColor(.yellow)
-                    .font(.caption2)
+                    .font(.system(size: 14, weight: .semibold))
             }
             Text(String(format: "%.1f", rating))
-                .appTextStyle(.caption2, weight: .semibold)
+                .appTextStyle(.footnote, weight: .semibold)
                 .foregroundColor(.secondary)
         }
         .accessibilityElement(children: .ignore)

--- a/yummr/UserPostsFeedView.swift
+++ b/yummr/UserPostsFeedView.swift
@@ -27,12 +27,12 @@ struct UserPostsFeedView: View {
                 } else {
                     LazyVStack(spacing: 24) {
                         ForEach(posts) { post in
-                            let fallbackID = post.id ?? "\(post.title)-\(post.timestamp.timeIntervalSince1970)"
+                            let identifier = post.stableIdentifier
                             NavigationLink(destination: PostDetailView(post: post)) {
                                 PostCard(post: post)
                             }
                             .buttonStyle(.plain)
-                            .id(fallbackID)
+                            .id(identifier)
                         }
                     }
                     .padding()
@@ -41,7 +41,7 @@ struct UserPostsFeedView: View {
             .onChange(of: posts) { _ in
                 guard !hasScrolledToInitialPost,
                       let targetID = initialPostID,
-                      posts.contains(where: { $0.id == targetID }) else { return }
+                      posts.contains(where: { $0.stableIdentifier == targetID }) else { return }
                 withAnimation {
                     proxy.scrollTo(targetID, anchor: .top)
                 }

--- a/yummr/UserPostsFeedView.swift
+++ b/yummr/UserPostsFeedView.swift
@@ -5,33 +5,52 @@ import FirebaseFirestore
 struct UserPostsFeedView: View {
     let authorID: String
     var authorName: String?
+    var initialPostID: String? = nil
 
     @State private var posts: [Post] = []
     @State private var isLoading = true
     @State private var listener: ListenerRegistration?
+    @State private var hasScrolledToInitialPost = false
 
     private let db = Firestore.firestore()
 
     var body: some View {
-        ScrollView {
-            if isLoading {
-                ProgressView()
-                    .padding()
-            } else if posts.isEmpty {
-                Text("No posts yet.")
-                    .foregroundColor(.secondary)
-                    .padding()
-            } else {
-                LazyVStack(spacing: 24) {
-                    ForEach(posts) { post in
-                        PostCard(post: post)
+        ScrollViewReader { proxy in
+            ScrollView {
+                if isLoading {
+                    ProgressView()
+                        .padding()
+                } else if posts.isEmpty {
+                    Text("No posts yet.")
+                        .foregroundColor(.secondary)
+                        .padding()
+                } else {
+                    LazyVStack(spacing: 24) {
+                        ForEach(posts) { post in
+                            let fallbackID = post.id ?? "\(post.title)-\(post.timestamp.timeIntervalSince1970)"
+                            NavigationLink(destination: PostDetailView(post: post)) {
+                                PostCard(post: post)
+                            }
+                            .buttonStyle(.plain)
+                            .id(fallbackID)
+                        }
                     }
+                    .padding()
                 }
-                .padding()
+            }
+            .onChange(of: posts) { _ in
+                guard !hasScrolledToInitialPost,
+                      let targetID = initialPostID,
+                      posts.contains(where: { $0.id == targetID }) else { return }
+                withAnimation {
+                    proxy.scrollTo(targetID, anchor: .top)
+                }
+                hasScrolledToInitialPost = true
             }
         }
         .navigationTitle(title)
         .onAppear {
+            hasScrolledToInitialPost = false
             startListeningForPosts()
         }
         .onDisappear {

--- a/yummr/yummrApp.swift
+++ b/yummr/yummrApp.swift
@@ -6,9 +6,12 @@
 //
 import SwiftUI
 import FirebaseCore
+import UIKit
 
 @main
 struct YummrApp: App {
+    @UIApplicationDelegateAdaptor(OrientationAppDelegate.self) private var orientationDelegate
+
     init() {
         Self.configureFirebaseIfNeeded()
     }
@@ -72,4 +75,10 @@ private struct AppRootView: View {
 enum FirebaseBootstrapState {
     static var resolvedBundleMismatch = false
     static var warning: String?
+}
+
+final class OrientationAppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        .portrait
+    }
 }


### PR DESCRIPTION
## Summary
- prevent the AI draft workshop from overwriting titles/captions and clean recipe steps rendered from stored drafts
- refresh post cards with a share sheet, enlarged ratings, and edge-to-edge media while preserving favorite badges
- overhaul the profile experience with pinned favorites, follow/unfollow controls, a grid that opens the author feed, safer people suggestions, and tab reselect back behavior while locking the app to portrait

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb212306008323a4a50f2773d855c4