### PR TITLE
Add in-app notifications, comment likes, and minor UI/UX tweaks

### DIFF
--- a/yummr/AIDraftWorkshopView.swift
+++ b/yummr/AIDraftWorkshopView.swift
@@ -25,7 +25,7 @@ struct AIDraftWorkshopView: View {
     @State private var capturedReferenceImage: UIImage?
 
     private var aiButtonTitle: String {
-        lastGeneratedDate == nil ? "Draft with AI" : "Regenerate with AI"
+        lastGeneratedDate == nil ? "Auto Log with AI" : "Regenerate Auto Log"
     }
 
     private let ingredientColumns: [GridItem] = [GridItem(.adaptive(minimum: 120), spacing: 8)]
@@ -68,7 +68,7 @@ struct AIDraftWorkshopView: View {
             }
             .padding()
         }
-        .navigationTitle("AI Draft")
+        .navigationTitle("Auto Log")
         .navigationBarTitleDisplayMode(.inline)
         .contentShape(Rectangle())
         .onTapGesture {
@@ -108,10 +108,10 @@ struct AIDraftWorkshopView: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Workshop your post with AI")
+            Text("Auto-log your post with AI")
                 .font(.title2)
                 .fontWeight(.semibold)
-            Text("Use voice notes, photos, and ingredients to generate a clean draft before heading back to the post composer.")
+            Text("Use voice notes and photos to generate a clean draft before heading back to the post composer.")
                 .font(.callout)
                 .foregroundColor(.secondary)
         }
@@ -119,9 +119,9 @@ struct AIDraftWorkshopView: View {
 
     private var aiDraftingControls: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("AI Drafting")
+            Text("Auto Log")
                 .font(.headline)
-            Text("Use your transcript, photos, and ingredients to draft a recipe.")
+            Text("Use your transcript and photos to auto-complete a recipe draft.")
                 .font(.callout)
                 .foregroundColor(.secondary)
 

--- a/yummr/AllCommentsView.swift
+++ b/yummr/AllCommentsView.swift
@@ -148,6 +148,16 @@ struct AllCommentsView: View {
                         .foregroundColor(.secondary)
                 }
 
+                Button {
+                    toggleCommentLike(comment)
+                } label: {
+                    Label(commentLikeLabel(for: comment),
+                          systemImage: commentIsLiked(comment) ? "heart.fill" : "heart")
+                        .font(.caption)
+                        .foregroundColor(commentIsLiked(comment) ? .red : .secondary)
+                }
+                .buttonStyle(.plain)
+
                 Button("Reply") {
                     replyingTo = comment
                 }
@@ -286,6 +296,8 @@ struct AllCommentsView: View {
                     authorName: authorHandle,
                     parentCommentID: parentID,
                     taggedUserIDs: taggedIDs,
+                    likedBy: [],
+                    likeCount: 0,
                     timestamp: Date()
                 )
 
@@ -295,6 +307,16 @@ struct AllCommentsView: View {
                         newComment = ""
                         replyingTo = nil
                         mentionSuggestions = []
+                    }
+                    if post.authorID != uid {
+                        let message = "\(authorHandle) commented on your post"
+                        NotificationService.shared.createNotification(
+                            to: post.authorID,
+                            type: .comment,
+                            actorID: uid,
+                            message: message,
+                            postID: postID
+                        )
                     }
                 } catch {
                     print("Error posting comment: \(error)")
@@ -464,5 +486,29 @@ struct AllCommentsView: View {
                 .document(commentID)
                 .delete()
         }
+    }
+
+    private func toggleCommentLike(_ comment: Comment) {
+        guard let postID = post.id,
+              let commentID = comment.id else { return }
+        CommentService.shared.toggleLike(
+            postID: postID,
+            commentID: commentID,
+            parentCommentID: comment.parentCommentID
+        ) { result in
+            if case .failure(let error) = result {
+                print("Failed to like comment: \(error)")
+            }
+        }
+    }
+
+    private func commentIsLiked(_ comment: Comment) -> Bool {
+        guard let uid = auth.currentUser?.uid else { return false }
+        return comment.resolvedLikedBy.contains(uid)
+    }
+
+    private func commentLikeLabel(for comment: Comment) -> String {
+        let count = comment.resolvedLikeCount
+        return count > 0 ? "\(count)" : "Like"
     }
 }

--- a/yummr/Comment.swift
+++ b/yummr/Comment.swift
@@ -8,6 +8,8 @@ struct Comment: Identifiable, Codable {
     var authorName: String
     var parentCommentID: String?
     var taggedUserIDs: [String]
+    var likedBy: [String]?
+    var likeCount: Int?
     @ServerTimestamp var timestamp: Date?
 
     init(id: String? = nil,
@@ -16,6 +18,8 @@ struct Comment: Identifiable, Codable {
          authorName: String,
          parentCommentID: String? = nil,
          taggedUserIDs: [String] = [],
+         likedBy: [String]? = nil,
+         likeCount: Int? = nil,
          timestamp: Date? = nil) {
         self.id = id
         self.text = text
@@ -23,6 +27,18 @@ struct Comment: Identifiable, Codable {
         self.authorName = authorName
         self.parentCommentID = parentCommentID
         self.taggedUserIDs = taggedUserIDs
+        self.likedBy = likedBy
+        self.likeCount = likeCount
         self.timestamp = timestamp
+    }
+}
+
+extension Comment {
+    var resolvedLikedBy: [String] {
+        likedBy ?? []
+    }
+
+    var resolvedLikeCount: Int {
+        likeCount ?? resolvedLikedBy.count
     }
 }

--- a/yummr/CommentService.swift
+++ b/yummr/CommentService.swift
@@ -1,0 +1,76 @@
+import Foundation
+import FirebaseAuth
+import FirebaseFirestore
+
+final class CommentService {
+    static let shared = CommentService()
+    private let db = Firestore.firestore()
+
+    private init() {}
+
+    func toggleLike(postID: String,
+                    commentID: String,
+                    parentCommentID: String?,
+                    completion: @escaping (Result<Void, Error>) -> Void) {
+        guard let uid = Auth.auth().currentUser?.uid else {
+            completion(.failure(NSError(
+                domain: "AuthError",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "User not logged in."]
+            )))
+            return
+        }
+
+        let commentRef = commentReference(postID: postID, commentID: commentID, parentCommentID: parentCommentID)
+
+        db.runTransaction({ transaction, errorPointer in
+            let snapshot: DocumentSnapshot
+            do {
+                snapshot = try transaction.getDocument(commentRef)
+            } catch let error {
+                errorPointer?.pointee = error as NSError
+                return nil
+            }
+
+            var likedBy = snapshot.data()?["likedBy"] as? [String] ?? []
+            var likeCount = snapshot.data()?["likeCount"] as? Int ?? likedBy.count
+
+            if likedBy.contains(uid) {
+                likedBy.removeAll { $0 == uid }
+                likeCount = max(0, likeCount - 1)
+            } else {
+                likedBy.append(uid)
+                likeCount += 1
+            }
+
+            transaction.updateData([
+                "likedBy": likedBy,
+                "likeCount": likeCount
+            ], forDocument: commentRef)
+
+            return nil
+        }) { _, error in
+            if let error = error {
+                completion(.failure(error))
+            } else {
+                completion(.success(()))
+            }
+        }
+    }
+
+    private func commentReference(postID: String, commentID: String, parentCommentID: String?) -> DocumentReference {
+        if let parentID = parentCommentID, !parentID.isEmpty {
+            return db.collection("posts")
+                .document(postID)
+                .collection("comments")
+                .document(parentID)
+                .collection("replies")
+                .document(commentID)
+        }
+
+        return db.collection("posts")
+            .document(postID)
+            .collection("comments")
+            .document(commentID)
+    }
+}

--- a/yummr/CreatePostView.swift
+++ b/yummr/CreatePostView.swift
@@ -122,7 +122,7 @@ struct CreatePostView: View {
                             aiNotes: $aiNotes
                         )
                     } label: {
-                        Label("Draft with AI", systemImage: "wand.and.stars")
+                        Label("Auto Log with AI", systemImage: "wand.and.stars")
                             .font(.headline)
                             .frame(maxWidth: .infinity)
                             .padding()

--- a/yummr/FeedView.swift
+++ b/yummr/FeedView.swift
@@ -34,7 +34,7 @@ struct FeedView: View {
                 .padding(.vertical, 12)
             }
             .navigationTitle("The Feed")
-            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarTitleDisplayMode(.large)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {

--- a/yummr/NotificationService.swift
+++ b/yummr/NotificationService.swift
@@ -55,4 +55,50 @@ final class NotificationService: ObservableObject {
                 batch.commit()
             }
     }
+
+    func createNotification(
+        to recipientID: String,
+        type: AppNotification.Kind,
+        actorID: String,
+        message: String,
+        postID: String? = nil
+    ) {
+        guard recipientID != actorID else { return }
+
+        UserService.shared.fetchUser(withID: recipientID) { user in
+            let settings = user?.resolvedNotificationSettings ?? .default
+            if settings.mutedUserIDs?.contains(actorID) == true {
+                return
+            }
+
+            switch type {
+            case .like where settings.likes == false:
+                return
+            case .comment where settings.comments == false:
+                return
+            case .friendRequest where settings.friendRequests == false:
+                return
+            default:
+                break
+            }
+
+            let notification = AppNotification(
+                type: type,
+                actorID: actorID,
+                message: message,
+                postID: postID,
+                createdAt: Date(),
+                isRead: false
+            )
+
+            do {
+                _ = try self.db.collection("users")
+                    .document(recipientID)
+                    .collection("notifications")
+                    .addDocument(from: notification)
+            } catch {
+                print("Failed to create notification: \(error)")
+            }
+        }
+    }
 }

--- a/yummr/PostCard.swift
+++ b/yummr/PostCard.swift
@@ -211,11 +211,22 @@ struct PostCard: View {
             Button {
                 showAllComments = true
             } label: {
-                Text("View all comments (\(commentCount))")
+                Text(commentPreviewLabel)
                     .appTextStyle(.footnote, weight: .semibold)
                     .foregroundColor(.accentColor)
             }
             .buttonStyle(.plain)
+        }
+    }
+
+    private var commentPreviewLabel: String {
+        switch commentCount {
+        case 1:
+            return "View 1 comment"
+        case let count where count > 1:
+            return "View all comments (\(count))"
+        default:
+            return "View comments"
         }
     }
 

--- a/yummr/PostDetailView.swift
+++ b/yummr/PostDetailView.swift
@@ -277,10 +277,23 @@ struct PostDetailView: View {
                     highlightMentions(in: comment.text)
                         .appTextStyle(.callout)
 
-                    if let timestamp = comment.timestamp {
-                        Text(timestamp.formatted(date: .abbreviated, time: .shortened))
-                            .appTextStyle(.caption2)
-                            .foregroundColor(.secondary)
+                    HStack(spacing: 12) {
+                        if let timestamp = comment.timestamp {
+                            Text(timestamp.formatted(date: .abbreviated, time: .shortened))
+                                .appTextStyle(.caption2)
+                                .foregroundColor(.secondary)
+                        }
+
+                        Button {
+                            toggleCommentLike(comment)
+                        } label: {
+                            Label(commentLikeLabel(for: comment),
+                                  systemImage: commentIsLiked(comment) ? "heart.fill" : "heart")
+                                .labelStyle(.titleAndIcon)
+                                .appTextStyle(.caption, weight: .medium)
+                                .foregroundColor(commentIsLiked(comment) ? .red : .secondary)
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
                 .padding(.vertical, 6)
@@ -423,6 +436,8 @@ struct PostDetailView: View {
                     authorName: authorHandle,
                     parentCommentID: nil,
                     taggedUserIDs: taggedIDs,
+                    likedBy: [],
+                    likeCount: 0,
                     timestamp: Date()
                 )
 
@@ -432,6 +447,16 @@ struct PostDetailView: View {
                         newComment = ""
                         mentionSuggestions = []
                         mentionLookup = [:]
+                    }
+                    if livePost.authorID != user.uid {
+                        let message = "\(authorHandle) commented on your post"
+                        NotificationService.shared.createNotification(
+                            to: livePost.authorID,
+                            type: .comment,
+                            actorID: user.uid,
+                            message: message,
+                            postID: postID
+                        )
                     }
                 } catch {
                     print("Error posting comment: \(error)")
@@ -518,6 +543,30 @@ struct PostDetailView: View {
                 }
             }
         }
+    }
+
+    private func toggleCommentLike(_ comment: Comment) {
+        guard let postID = livePost.id ?? post.id,
+              let commentID = comment.id else { return }
+        CommentService.shared.toggleLike(
+            postID: postID,
+            commentID: commentID,
+            parentCommentID: comment.parentCommentID
+        ) { result in
+            if case .failure(let error) = result {
+                print("Failed to like comment: \(error)")
+            }
+        }
+    }
+
+    private func commentIsLiked(_ comment: Comment) -> Bool {
+        guard let uid = auth.currentUser?.uid else { return false }
+        return comment.resolvedLikedBy.contains(uid)
+    }
+
+    private func commentLikeLabel(for comment: Comment) -> String {
+        let count = comment.resolvedLikeCount
+        return count > 0 ? "\(count)" : "Like"
     }
 
     private func checkSaveState() {

--- a/yummr/PostService.swift
+++ b/yummr/PostService.swift
@@ -14,7 +14,13 @@ class PostService: ObservableObject {
     @Published var cachedTopPosts: [Post] = []
 
     func toggleLike(for post: Post, completion: @escaping (Result<Void, Error>) -> Void) {
-        guard let uid = Auth.auth().currentUser?.uid else { return }
+        guard let uid = Auth.auth().currentUser?.uid else {
+            completion(.failure(
+                NSError(domain: "AuthError", code: 0,
+                        userInfo: [NSLocalizedDescriptionKey: "User not logged in."])
+            ))
+            return
+        }
         guard let postID = post.id else {
             completion(.failure(
                 NSError(domain: "PostError", code: 0,
@@ -35,8 +41,9 @@ class PostService: ObservableObject {
 
             var likedBy = postDoc.data()?["likedBy"] as? [String] ?? []
             var likeCount = postDoc.data()?["likeCount"] as? Int ?? 0
+            let wasLiked = likedBy.contains(uid)
 
-            if likedBy.contains(uid) {
+            if wasLiked {
                 likedBy.removeAll { $0 == uid }
                 likeCount = max(0, likeCount - 1)
             } else {
@@ -49,12 +56,27 @@ class PostService: ObservableObject {
                 "likeCount": likeCount
             ], forDocument: postRef)
 
-            return nil
-        }) { _, error in
+            return wasLiked
+        }) { result, error in
             if let error = error {
                 completion(.failure(error))
             } else {
                 completion(.success(()))
+                let wasLiked = result as? Bool ?? true
+                if !wasLiked, post.authorID != uid {
+                    UserService.shared.fetchUser(withID: uid) { user in
+                        let actorName = HandleFormatter.normalizedHandleIfPresent(user?.handle)
+                            ?? HandleFormatter.normalizedHandle(from: user?.displayName ?? "Someone")
+                        let message = "\(actorName) liked your post"
+                        NotificationService.shared.createNotification(
+                            to: post.authorID,
+                            type: .like,
+                            actorID: uid,
+                            message: message,
+                            postID: post.id
+                        )
+                    }
+                }
             }
         }
     }

--- a/yummr/RootView.swift
+++ b/yummr/RootView.swift
@@ -15,46 +15,28 @@ struct RootView: View {
 
     @StateObject var auth = AuthService()
     @State private var selectedTab: Tab = .feed
-    @State private var feedViewID = UUID()
-    @State private var searchViewID = UUID()
-    @State private var createViewID = UUID()
-    @State private var savedViewID = UUID()
-    @State private var profileViewID = UUID()
 
     var body: some View {
         Group {
             if auth.currentUser != nil {
-                TabView(selection: Binding(
-                    get: { selectedTab },
-                    set: { newValue in
-                        if selectedTab == newValue {
-                            resetView(for: newValue)
-                        }
-                        selectedTab = newValue
-                    }
-                )) {
+                TabView(selection: $selectedTab) {
                     FeedView()
-                        .id(feedViewID)
                         .tabItem { Label("Feed",    systemImage: "list.bullet") }
                         .tag(Tab.feed)
 
                     SearchView()
-                        .id(searchViewID)
                         .tabItem { Label("Search",  systemImage: "magnifyingglass") }
                         .tag(Tab.search)
 
                     CreatePostView()
-                        .id(createViewID)
                         .tabItem { Label("Create",  systemImage: "plus.circle") }
                         .tag(Tab.create)
 
                     SavedCollectionsView()
-                        .id(savedViewID)
                         .tabItem { Label("Saved", systemImage: "bookmark") }
                         .tag(Tab.saved)
 
                     ProfileView()
-                        .id(profileViewID)
                         .tabItem { Label("Profile", systemImage: "person.crop.circle") }
                         .tag(Tab.profile)
                 }
@@ -63,20 +45,5 @@ struct RootView: View {
             }
         }
         .environmentObject(auth)
-    }
-
-    private func resetView(for tab: Tab) {
-        switch tab {
-        case .feed:
-            feedViewID = UUID()
-        case .search:
-            searchViewID = UUID()
-        case .create:
-            createViewID = UUID()
-        case .saved:
-            savedViewID = UUID()
-        case .profile:
-            profileViewID = UUID()
-        }
     }
 }

--- a/yummr/UserService.swift
+++ b/yummr/UserService.swift
@@ -161,7 +161,13 @@ final class UserService: ObservableObject {
 
      
                 let lowercasedQuery = normalizedQuery.lowercased()
-                let users: [AppUser] = documents.compactMap { try? $0.data(as: AppUser.self) }
+                let users: [AppUser] = documents.compactMap { document in
+                    guard var user = try? document.data(as: AppUser.self) else { return nil }
+                    if user.id == nil {
+                        user.id = document.documentID
+                    }
+                    return user
+                }
                     .sorted { ($0.displayName.lowercased(), $0.handle.lowercased()) < ($1.displayName.lowercased(), $1.handle.lowercased()) }
                     .filter { user in
                         let handle = user.handle.lowercased()


### PR DESCRIPTION
### Motivation

- Surface and persist interactions so users get notified when their posts are liked or commented on. 
- Add the ability to like/comments (heart) so comment engagement behaves like post likes. 
- Improve UX language and presentation for the AI drafting flow and feed header. 
- Keep tab view state consistent and ensure search results include usable user IDs for navigation.

### Description

- Added `CommentService` with `toggleLike` and extended the `Comment` model to store `likedBy` and `likeCount`, plus convenience accessors (`resolvedLikedBy`/`resolvedLikeCount`). 
- Plumbed comment-like UI into `PostDetailView` and `AllCommentsView` with buttons and labels, and update Firestore via `CommentService`. 
- Implemented `NotificationService.createNotification(...)` that respects user notification settings and added notification creation for post likes (in `PostService.toggleLike`) and for new comments (in `PostDetailView`/`AllCommentsView`). 
- Small UI/UX changes: updated AI draft wording to "Auto Log" (`CreatePostView` / `AIDraftWorkshopView`), made feed title large (`FeedView`), improved comment preview wording (`PostCard`), prevented tab view resets by simplifying `RootView` tab handling, and ensured `UserService.searchUsers` populates missing `id` values so search items are clickable.

### Testing

- No automated tests were run for these changes. 
- Static compilation and basic local project changes were prepared and committed; runtime verification on device/simulator is recommended. 
- Core Firestore operations use transactions and existing error paths to report failures to callers. 
- Notification creation respects `AppUser.notificationSettings` and will not create notifications for muted users or disabled types.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696083b261d88323a3cbc81452e6b369)