### PR TITLE
Display "calories" instead of "kcal" in post metadata

### DIFF
--- a/yummr/AIDraftWorkshopView.swift
+++ b/yummr/AIDraftWorkshopView.swift
@@ -25,7 +25,7 @@ struct AIDraftWorkshopView: View {
     @State private var capturedReferenceImage: UIImage?
 
     private var aiButtonTitle: String {
-        lastGeneratedDate == nil ? "Draft with AI" : "Regenerate with AI"
+        lastGeneratedDate == nil ? "Auto Log with AI" : "Regenerate Auto Log"
     }
 
     private let ingredientColumns: [GridItem] = [GridItem(.adaptive(minimum: 120), spacing: 8)]
@@ -68,7 +68,7 @@ struct AIDraftWorkshopView: View {
             }
             .padding()
         }
-        .navigationTitle("AI Draft")
+        .navigationTitle("Auto Log")
         .navigationBarTitleDisplayMode(.inline)
         .contentShape(Rectangle())
         .onTapGesture {
@@ -108,10 +108,10 @@ struct AIDraftWorkshopView: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Workshop your post with AI")
+            Text("Auto-log your post with AI")
                 .font(.title2)
                 .fontWeight(.semibold)
-            Text("Use voice notes, photos, and ingredients to generate a clean draft before heading back to the post composer.")
+            Text("Use voice notes and photos to generate a clean draft before heading back to the post composer.")
                 .font(.callout)
                 .foregroundColor(.secondary)
         }
@@ -119,9 +119,9 @@ struct AIDraftWorkshopView: View {
 
     private var aiDraftingControls: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("AI Drafting")
+            Text("Auto Log")
                 .font(.headline)
-            Text("Use your transcript, photos, and ingredients to draft a recipe.")
+            Text("Use your transcript and photos to auto-complete a recipe draft.")
                 .font(.callout)
                 .foregroundColor(.secondary)
 

--- a/yummr/AllCommentsView.swift
+++ b/yummr/AllCommentsView.swift
@@ -148,6 +148,16 @@ struct AllCommentsView: View {
                         .foregroundColor(.secondary)
                 }
 
+                Button {
+                    toggleCommentLike(comment)
+                } label: {
+                    Label(commentLikeLabel(for: comment),
+                          systemImage: commentIsLiked(comment) ? "heart.fill" : "heart")
+                        .font(.caption)
+                        .foregroundColor(commentIsLiked(comment) ? .red : .secondary)
+                }
+                .buttonStyle(.plain)
+
                 Button("Reply") {
                     replyingTo = comment
                 }
@@ -286,6 +296,8 @@ struct AllCommentsView: View {
                     authorName: authorHandle,
                     parentCommentID: parentID,
                     taggedUserIDs: taggedIDs,
+                    likedBy: [],
+                    likeCount: 0,
                     timestamp: Date()
                 )
 
@@ -295,6 +307,16 @@ struct AllCommentsView: View {
                         newComment = ""
                         replyingTo = nil
                         mentionSuggestions = []
+                    }
+                    if post.authorID != uid {
+                        let message = "\(authorHandle) commented on your post"
+                        NotificationService.shared.createNotification(
+                            to: post.authorID,
+                            type: .comment,
+                            actorID: uid,
+                            message: message,
+                            postID: postID
+                        )
                     }
                 } catch {
                     print("Error posting comment: \(error)")
@@ -464,5 +486,29 @@ struct AllCommentsView: View {
                 .document(commentID)
                 .delete()
         }
+    }
+
+    private func toggleCommentLike(_ comment: Comment) {
+        guard let postID = post.id,
+              let commentID = comment.id else { return }
+        CommentService.shared.toggleLike(
+            postID: postID,
+            commentID: commentID,
+            parentCommentID: comment.parentCommentID
+        ) { result in
+            if case .failure(let error) = result {
+                print("Failed to like comment: \(error)")
+            }
+        }
+    }
+
+    private func commentIsLiked(_ comment: Comment) -> Bool {
+        guard let uid = auth.currentUser?.uid else { return false }
+        return comment.resolvedLikedBy.contains(uid)
+    }
+
+    private func commentLikeLabel(for comment: Comment) -> String {
+        let count = comment.resolvedLikeCount
+        return count > 0 ? "\(count)" : "Like"
     }
 }

--- a/yummr/AutoLogFlowView.swift
+++ b/yummr/AutoLogFlowView.swift
@@ -1,0 +1,465 @@
+import SwiftUI
+import PhotosUI
+import UIKit
+
+struct AutoLogSheetView: View {
+    @Binding var title: String
+    @Binding var description: String
+    @Binding var recipe: AttributedString
+    @Binding var ingredients: [String]
+    @Binding var selectedImages: [UIImage]
+    @Binding var aiReferenceImages: [UIImage]
+    @Binding var audioTranscript: String
+    @Binding var cookTime: String
+    @Binding var calorieEstimate: String
+    @Binding var aiNotes: [String]
+
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var audioRecorder = AudioRecorderService()
+
+    @State private var referencePhotoItems: [PhotosPickerItem] = []
+    @State private var showReferenceCamera = false
+    @State private var capturedReferenceImage: UIImage?
+    @State private var isDrafting = false
+    @State private var errorMessage: String?
+    @State private var draftState: AutoLogDraftState?
+    @State private var showDraftReview = false
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    Text("Auto-log with AI")
+                        .font(.title2)
+                        .fontWeight(.semibold)
+
+                    Text("Capture a voice memo and optional reference photos. We'll draft a recipe you can review.")
+                        .font(.callout)
+                        .foregroundColor(.secondary)
+
+                    voiceSection
+                    referencePhotosSection
+
+                    Button {
+                        requestAIDraft()
+                    } label: {
+                        Label(isDrafting ? "Drafting..." : "Draft with AI", systemImage: "wand.and.stars")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isDrafting)
+
+                    if let errorMessage {
+                        Text(errorMessage)
+                            .font(.footnote)
+                            .foregroundColor(.red)
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Auto Log")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Close") { dismiss() }
+                }
+            }
+        }
+        .onAppear { audioRecorder.requestPermissions() }
+        .onReceive(audioRecorder.$transcript) { transcript in
+            guard !transcript.isEmpty else { return }
+            audioTranscript = transcript
+        }
+        .sheet(isPresented: $showReferenceCamera) {
+            ImagePicker(image: $capturedReferenceImage, sourceType: .camera)
+        }
+        .onChange(of: referencePhotoItems) { items in
+            Task {
+                var loadedImages: [UIImage] = []
+                for item in items {
+                    if let data = try? await item.loadTransferable(type: Data.self),
+                       let image = UIImage(data: data) {
+                        loadedImages.append(image)
+                    }
+                }
+                if !loadedImages.isEmpty {
+                    aiReferenceImages.append(contentsOf: loadedImages)
+                }
+                referencePhotoItems = []
+            }
+        }
+        .onChange(of: capturedReferenceImage) { image in
+            guard let image = image else { return }
+            aiReferenceImages.append(image)
+            capturedReferenceImage = nil
+        }
+        .sheet(isPresented: $showDraftReview) {
+            if let draftState {
+                AutoLogDraftReviewView(draft: draftState) { reviewed in
+                    applyDraft(reviewed)
+                    dismiss()
+                }
+            }
+        }
+    }
+
+    private var voiceSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Voice Memo")
+                .font(.headline)
+
+            HStack(spacing: 16) {
+                Button {
+                    if audioRecorder.isRecording {
+                        audioRecorder.stopRecording()
+                    } else {
+                        audioRecorder.startRecording()
+                    }
+                } label: {
+                    Label(audioRecorder.isRecording ? "Stop Recording" : "Record Idea",
+                          systemImage: audioRecorder.isRecording ? "stop.circle.fill" : "mic.circle.fill")
+                        .font(.headline)
+                        .labelStyle(.titleAndIcon)
+                }
+                .buttonStyle(.bordered)
+                .tint(audioRecorder.isRecording ? .red : .accentColor)
+                .disabled(!audioRecorder.hasMicrophonePermission || audioRecorder.speechAuthorizationStatus != .authorized)
+
+                Text(formattedTime(audioRecorder.elapsedTime))
+                    .font(.system(.body, design: .monospaced))
+                    .foregroundColor(audioRecorder.isRecording ? .primary : .secondary)
+
+                Spacer()
+                Text("Max 60s")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if let errorMessage = audioRecorder.errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+
+            TextEditor(text: $audioTranscript)
+                .frame(minHeight: 120)
+                .padding(6)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                )
+        }
+        .padding()
+        .background(Color(UIColor.secondarySystemBackground))
+        .cornerRadius(12)
+    }
+
+    private var referencePhotosSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Reference Photos")
+                .font(.headline)
+            Text("Optional images to guide the AI. These won't post publicly.")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+
+            HStack(spacing: 16) {
+                PhotosPicker(
+                    selection: $referencePhotoItems,
+                    maxSelectionCount: 4,
+                    matching: .images,
+                    photoLibrary: .shared()
+                ) {
+                    Label("Add Photos", systemImage: "photo.on.rectangle")
+                }
+
+                Button {
+                    showReferenceCamera = true
+                } label: {
+                    Label("Capture", systemImage: "camera")
+                }
+                .disabled(!UIImagePickerController.isSourceTypeAvailable(.camera))
+            }
+
+            if aiReferenceImages.isEmpty {
+                Text("No reference photos yet.")
+                    .font(.callout)
+                    .foregroundColor(.secondary)
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 12) {
+                        ForEach(Array(aiReferenceImages.enumerated()), id: \.offset) { pair in
+                            let i = pair.offset
+                            let img = pair.element
+                            ZStack(alignment: .topTrailing) {
+                                Image(uiImage: img)
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: 120, height: 120)
+                                    .clipped()
+                                    .cornerRadius(12)
+
+                                Button {
+                                    withAnimation {
+                                        if i < aiReferenceImages.count {
+                                            aiReferenceImages.remove(at: i)
+                                        }
+                                    }
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .font(.title3)
+                                        .symbolRenderingMode(.multicolor)
+                                }
+                                .offset(x: 6, y: -6)
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(Color(UIColor.secondarySystemBackground))
+        .cornerRadius(12)
+    }
+
+    private func requestAIDraft() {
+        Task {
+            await performDraftRequest()
+        }
+    }
+
+    @MainActor
+    private func performDraftRequest() async {
+        guard !isDrafting else { return }
+        isDrafting = true
+        errorMessage = nil
+
+        do {
+            let draft = try await AIRecipeService.shared.generateDraft(
+                currentTitle: title,
+                currentDescription: description,
+                currentRecipe: recipe.plainText,
+                transcript: audioTranscript,
+                capturedIdeas: [],
+                customPrompt: "",
+                ingredients: ingredients,
+                images: selectedImages,
+                referenceImages: aiReferenceImages
+            )
+            draftState = AutoLogDraftState(from: draft)
+            showDraftReview = true
+        } catch {
+            if let localized = error as? LocalizedError, let description = localized.errorDescription {
+                errorMessage = description
+            } else {
+                errorMessage = error.localizedDescription
+            }
+        }
+
+        isDrafting = false
+    }
+
+    private func applyDraft(_ draft: AutoLogDraftState) {
+        title = draft.title
+        description = draft.description
+        cookTime = draft.cookTime
+        calorieEstimate = draft.calorieEstimate
+        ingredients = draft.ingredients
+        aiNotes = draft.notes
+        recipe = AttributedString(draft.recipeText)
+    }
+
+    private func formattedTime(_ interval: TimeInterval) -> String {
+        let totalSeconds = max(0, Int(interval))
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+        return String(format: "%01d:%02d", minutes, seconds)
+    }
+}
+
+struct AutoLogDraftState {
+    var title: String
+    var description: String
+    var recipeText: String
+    var cookTime: String
+    var calorieEstimate: String
+    var ingredients: [String]
+    var notes: [String]
+
+    init(title: String,
+         description: String,
+         recipeText: String,
+         cookTime: String,
+         calorieEstimate: String,
+         ingredients: [String],
+         notes: [String]) {
+        self.title = title
+        self.description = description
+        self.recipeText = recipeText
+        self.cookTime = cookTime
+        self.calorieEstimate = calorieEstimate
+        self.ingredients = ingredients
+        self.notes = notes
+    }
+
+    init(from draft: AIRecipeDraft) {
+        let recipeText: String
+        if let steps = draft.instructions, !steps.isEmpty {
+            recipeText = steps.joined(separator: "\n")
+        } else {
+            recipeText = draft.recipe ?? ""
+        }
+
+        let cleanedIngredients = (draft.ingredients ?? [])
+            .map { stripCreativeTags($0) }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        let cleanedNotes = (draft.notes ?? [])
+            .map { stripCreativeTags($0) }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        self.title = stripCreativeTags(draft.title ?? "")
+        self.description = stripCreativeTags(draft.description ?? "")
+        self.recipeText = stripCreativeTags(recipeText)
+        self.cookTime = stripCreativeTags(draft.cookTime ?? "")
+        if let calories = draft.calorieEstimate, calories > 0 {
+            self.calorieEstimate = "\(calories)"
+        } else {
+            self.calorieEstimate = ""
+        }
+        self.ingredients = cleanedIngredients
+        self.notes = cleanedNotes
+    }
+
+    private static func stripCreativeTags(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "<creative>", with: "", options: .caseInsensitive)
+            .replacingOccurrences(of: "</creative>", with: "", options: .caseInsensitive)
+    }
+}
+
+struct AutoLogDraftReviewView: View {
+    let onConfirm: (AutoLogDraftState) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var title: String
+    @State private var description: String
+    @State private var recipeText: String
+    @State private var cookTime: String
+    @State private var calorieEstimate: String
+    @State private var ingredientsText: String
+    @State private var notesText: String
+
+    init(draft: AutoLogDraftState, onConfirm: @escaping (AutoLogDraftState) -> Void) {
+        self.onConfirm = onConfirm
+        _title = State(initialValue: draft.title)
+        _description = State(initialValue: draft.description)
+        _recipeText = State(initialValue: draft.recipeText)
+        _cookTime = State(initialValue: draft.cookTime)
+        _calorieEstimate = State(initialValue: draft.calorieEstimate)
+        _ingredientsText = State(initialValue: draft.ingredients.joined(separator: "\n"))
+        _notesText = State(initialValue: draft.notes.joined(separator: "\n"))
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    TextField("Title", text: $title)
+                        .textFieldStyle(.roundedBorder)
+
+                    TextEditor(text: $description)
+                        .frame(minHeight: 120)
+                        .padding(6)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                        )
+
+                    TextField("Cook Time", text: $cookTime)
+                        .textFieldStyle(.roundedBorder)
+
+                    TextField("Calories", text: $calorieEstimate)
+                        .keyboardType(.numberPad)
+                        .textFieldStyle(.roundedBorder)
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Ingredients")
+                            .font(.headline)
+                        TextEditor(text: $ingredientsText)
+                            .frame(minHeight: 120)
+                            .padding(6)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                            )
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Recipe")
+                            .font(.headline)
+                        TextEditor(text: $recipeText)
+                            .frame(minHeight: 200)
+                            .padding(6)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                            )
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Notes")
+                            .font(.headline)
+                        TextEditor(text: $notesText)
+                            .frame(minHeight: 100)
+                            .padding(6)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                            )
+                    }
+
+                    Button("Confirm Draft") {
+                        let ingredients = splitLines(from: ingredientsText)
+                        let notes = splitLines(from: notesText)
+                        let confirmed = AutoLogDraftState(
+                            title: stripCreativeTags(title),
+                            description: stripCreativeTags(description),
+                            recipeText: stripCreativeTags(recipeText),
+                            cookTime: stripCreativeTags(cookTime),
+                            calorieEstimate: stripCreativeTags(calorieEstimate),
+                            ingredients: ingredients,
+                            notes: notes
+                        )
+                        onConfirm(confirmed)
+                        dismiss()
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding()
+            }
+            .navigationTitle("Review Draft")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Back") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func splitLines(from text: String) -> [String] {
+        text
+            .components(separatedBy: CharacterSet.newlines.union([","]))
+            .map { stripCreativeTags($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private func stripCreativeTags(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "<creative>", with: "", options: .caseInsensitive)
+            .replacingOccurrences(of: "</creative>", with: "", options: .caseInsensitive)
+    }
+}

--- a/yummr/Comment.swift
+++ b/yummr/Comment.swift
@@ -8,6 +8,8 @@ struct Comment: Identifiable, Codable {
     var authorName: String
     var parentCommentID: String?
     var taggedUserIDs: [String]
+    var likedBy: [String]?
+    var likeCount: Int?
     @ServerTimestamp var timestamp: Date?
 
     init(id: String? = nil,
@@ -16,6 +18,8 @@ struct Comment: Identifiable, Codable {
          authorName: String,
          parentCommentID: String? = nil,
          taggedUserIDs: [String] = [],
+         likedBy: [String]? = nil,
+         likeCount: Int? = nil,
          timestamp: Date? = nil) {
         self.id = id
         self.text = text
@@ -23,6 +27,18 @@ struct Comment: Identifiable, Codable {
         self.authorName = authorName
         self.parentCommentID = parentCommentID
         self.taggedUserIDs = taggedUserIDs
+        self.likedBy = likedBy
+        self.likeCount = likeCount
         self.timestamp = timestamp
+    }
+}
+
+extension Comment {
+    var resolvedLikedBy: [String] {
+        likedBy ?? []
+    }
+
+    var resolvedLikeCount: Int {
+        likeCount ?? resolvedLikedBy.count
     }
 }

--- a/yummr/CommentService.swift
+++ b/yummr/CommentService.swift
@@ -1,0 +1,76 @@
+import Foundation
+import FirebaseAuth
+import FirebaseFirestore
+
+final class CommentService {
+    static let shared = CommentService()
+    private let db = Firestore.firestore()
+
+    private init() {}
+
+    func toggleLike(postID: String,
+                    commentID: String,
+                    parentCommentID: String?,
+                    completion: @escaping (Result<Void, Error>) -> Void) {
+        guard let uid = Auth.auth().currentUser?.uid else {
+            completion(.failure(NSError(
+                domain: "AuthError",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "User not logged in."]
+            )))
+            return
+        }
+
+        let commentRef = commentReference(postID: postID, commentID: commentID, parentCommentID: parentCommentID)
+
+        db.runTransaction({ transaction, errorPointer in
+            let snapshot: DocumentSnapshot
+            do {
+                snapshot = try transaction.getDocument(commentRef)
+            } catch let error {
+                errorPointer?.pointee = error as NSError
+                return nil
+            }
+
+            var likedBy = snapshot.data()?["likedBy"] as? [String] ?? []
+            var likeCount = snapshot.data()?["likeCount"] as? Int ?? likedBy.count
+
+            if likedBy.contains(uid) {
+                likedBy.removeAll { $0 == uid }
+                likeCount = max(0, likeCount - 1)
+            } else {
+                likedBy.append(uid)
+                likeCount += 1
+            }
+
+            transaction.updateData([
+                "likedBy": likedBy,
+                "likeCount": likeCount
+            ], forDocument: commentRef)
+
+            return nil
+        }) { _, error in
+            if let error = error {
+                completion(.failure(error))
+            } else {
+                completion(.success(()))
+            }
+        }
+    }
+
+    private func commentReference(postID: String, commentID: String, parentCommentID: String?) -> DocumentReference {
+        if let parentID = parentCommentID, !parentID.isEmpty {
+            return db.collection("posts")
+                .document(postID)
+                .collection("comments")
+                .document(parentID)
+                .collection("replies")
+                .document(commentID)
+        }
+
+        return db.collection("posts")
+            .document(postID)
+            .collection("comments")
+            .document(commentID)
+    }
+}

--- a/yummr/CreatePostView.swift
+++ b/yummr/CreatePostView.swift
@@ -57,6 +57,7 @@ struct CreatePostView: View {
     @State private var showCameraPicker = false
     @State private var cameraUnavailableAlert = false
     @State private var capturedImage: UIImage?
+    @State private var showAutoLogSheet = false
 
     @State private var taggingMode: TaggingMode = .post
     @State private var selectedImageIndex = 0
@@ -108,19 +109,8 @@ struct CreatePostView: View {
                         }
                     }
 
-                    NavigationLink {
-                        AIDraftWorkshopView(
-                            title: $title,
-                            description: $description,
-                            recipe: $recipe,
-                            ingredients: $ingredients,
-                            selectedImages: $selectedImages,
-                            aiReferenceImages: $aiReferenceImages,
-                            audioTranscript: $audioTranscript,
-                            cookTime: $cookTime,
-                            calorieEstimate: $calorieEstimate,
-                            aiNotes: $aiNotes
-                        )
+                    Button {
+                        showAutoLogSheet = true
                     } label: {
                         Label("Auto Log with AI", systemImage: "wand.and.stars")
                             .font(.headline)
@@ -182,6 +172,20 @@ struct CreatePostView: View {
         }
         .sheet(isPresented: $showCameraPicker) {
             ImagePicker(image: $capturedImage, sourceType: .camera)
+        }
+        .sheet(isPresented: $showAutoLogSheet) {
+            AutoLogSheetView(
+                title: $title,
+                description: $description,
+                recipe: $recipe,
+                ingredients: $ingredients,
+                selectedImages: $selectedImages,
+                aiReferenceImages: $aiReferenceImages,
+                audioTranscript: $audioTranscript,
+                cookTime: $cookTime,
+                calorieEstimate: $calorieEstimate,
+                aiNotes: $aiNotes
+            )
         }
         .alert("Camera unavailable", isPresented: $cameraUnavailableAlert) {
             Button("OK", role: .cancel) { }

--- a/yummr/CreatePostView.swift
+++ b/yummr/CreatePostView.swift
@@ -122,7 +122,7 @@ struct CreatePostView: View {
                             aiNotes: $aiNotes
                         )
                     } label: {
-                        Label("Draft with AI", systemImage: "wand.and.stars")
+                        Label("Auto Log with AI", systemImage: "wand.and.stars")
                             .font(.headline)
                             .frame(maxWidth: .infinity)
                             .padding()

--- a/yummr/FeedView.swift
+++ b/yummr/FeedView.swift
@@ -34,7 +34,7 @@ struct FeedView: View {
                 .padding(.vertical, 12)
             }
             .navigationTitle("The Feed")
-            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarTitleDisplayMode(.large)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {

--- a/yummr/NotificationService.swift
+++ b/yummr/NotificationService.swift
@@ -55,4 +55,50 @@ final class NotificationService: ObservableObject {
                 batch.commit()
             }
     }
+
+    func createNotification(
+        to recipientID: String,
+        type: AppNotification.Kind,
+        actorID: String,
+        message: String,
+        postID: String? = nil
+    ) {
+        guard recipientID != actorID else { return }
+
+        UserService.shared.fetchUser(withID: recipientID) { user in
+            let settings = user?.resolvedNotificationSettings ?? .default
+            if settings.mutedUserIDs?.contains(actorID) == true {
+                return
+            }
+
+            switch type {
+            case .like where settings.likes == false:
+                return
+            case .comment where settings.comments == false:
+                return
+            case .friendRequest where settings.friendRequests == false:
+                return
+            default:
+                break
+            }
+
+            let notification = AppNotification(
+                type: type,
+                actorID: actorID,
+                message: message,
+                postID: postID,
+                createdAt: Date(),
+                isRead: false
+            )
+
+            do {
+                _ = try self.db.collection("users")
+                    .document(recipientID)
+                    .collection("notifications")
+                    .addDocument(from: notification)
+            } catch {
+                print("Failed to create notification: \(error)")
+            }
+        }
+    }
 }

--- a/yummr/Post+Metadata.swift
+++ b/yummr/Post+Metadata.swift
@@ -37,7 +37,7 @@ extension Post {
 
     var formattedCalories: String? {
         guard let calories = calorieEstimate else { return nil }
-        return "\(calories) kcal"
+        return "\(calories) calories"
     }
 
     var notesList: [String] {

--- a/yummr/Post+Metadata.swift
+++ b/yummr/Post+Metadata.swift
@@ -40,6 +40,13 @@ extension Post {
         return "\(calories) calories"
     }
 
+    var cleanedCookTime: String? {
+        guard let cookTime, !cookTime.isEmpty else { return nil }
+        let cleaned = strippingCreativeTags(from: cookTime)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
     var notesList: [String] {
         let raw = extraFields?["notes"] ?? extraFields?["aiNotes"] ?? ""
         return parseList(from: raw)
@@ -83,7 +90,7 @@ extension Post {
     private func parseList(from string: String) -> [String] {
         string
             .components(separatedBy: CharacterSet(charactersIn: ",\n•"))
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .map { strippingCreativeTags(from: $0).trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
     }
 

--- a/yummr/PostCard.swift
+++ b/yummr/PostCard.swift
@@ -211,11 +211,22 @@ struct PostCard: View {
             Button {
                 showAllComments = true
             } label: {
-                Text("View all comments (\(commentCount))")
+                Text(commentPreviewLabel)
                     .appTextStyle(.footnote, weight: .semibold)
                     .foregroundColor(.accentColor)
             }
             .buttonStyle(.plain)
+        }
+    }
+
+    private var commentPreviewLabel: String {
+        switch commentCount {
+        case 1:
+            return "View 1 comment"
+        case let count where count > 1:
+            return "View all comments (\(count))"
+        default:
+            return "View comments"
         }
     }
 

--- a/yummr/PostCard.swift
+++ b/yummr/PostCard.swift
@@ -281,15 +281,6 @@ struct PostCard: View {
             }
         }
         .frame(height: UIScreen.main.bounds.width * 0.95)
-        .overlay(alignment: .topTrailing) {
-            if post.isFavorited {
-                Image(systemName: "bookmark.circle.fill")
-                    .font(.system(size: 26, weight: .semibold))
-                    .foregroundColor(.yellow)
-                    .padding(.trailing, 4)
-                    .padding(.top, 4)
-            }
-        }
     }
 
     private func tagOverlay(tag: Post.PhotoTag, size: CGSize) -> some View {

--- a/yummr/PostDetailView.swift
+++ b/yummr/PostDetailView.swift
@@ -109,11 +109,6 @@ struct PostDetailView: View {
                 if let rating = livePost.starRating {
                     StarRatingView(rating: rating)
                 }
-                if livePost.isFavorited {
-                    Image(systemName: "star.fill")
-                        .foregroundColor(.yellow)
-                        .font(.caption)
-                }
             }
 
             NavigationLink(destination: ProfileView(userID: livePost.authorID)) {
@@ -131,7 +126,7 @@ struct PostDetailView: View {
     }
 
     private var metaRow: some View {
-        let cookTime = livePost.cookTime?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cookTime = livePost.cleanedCookTime
         let calories = livePost.formattedCalories
         return HStack(spacing: 16) {
             if let cookTime, !cookTime.isEmpty {

--- a/yummr/PostDetailView.swift
+++ b/yummr/PostDetailView.swift
@@ -277,10 +277,23 @@ struct PostDetailView: View {
                     highlightMentions(in: comment.text)
                         .appTextStyle(.callout)
 
-                    if let timestamp = comment.timestamp {
-                        Text(timestamp.formatted(date: .abbreviated, time: .shortened))
-                            .appTextStyle(.caption2)
-                            .foregroundColor(.secondary)
+                    HStack(spacing: 12) {
+                        if let timestamp = comment.timestamp {
+                            Text(timestamp.formatted(date: .abbreviated, time: .shortened))
+                                .appTextStyle(.caption2)
+                                .foregroundColor(.secondary)
+                        }
+
+                        Button {
+                            toggleCommentLike(comment)
+                        } label: {
+                            Label(commentLikeLabel(for: comment),
+                                  systemImage: commentIsLiked(comment) ? "heart.fill" : "heart")
+                                .labelStyle(.titleAndIcon)
+                                .appTextStyle(.caption, weight: .medium)
+                                .foregroundColor(commentIsLiked(comment) ? .red : .secondary)
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
                 .padding(.vertical, 6)
@@ -423,6 +436,8 @@ struct PostDetailView: View {
                     authorName: authorHandle,
                     parentCommentID: nil,
                     taggedUserIDs: taggedIDs,
+                    likedBy: [],
+                    likeCount: 0,
                     timestamp: Date()
                 )
 
@@ -432,6 +447,16 @@ struct PostDetailView: View {
                         newComment = ""
                         mentionSuggestions = []
                         mentionLookup = [:]
+                    }
+                    if livePost.authorID != user.uid {
+                        let message = "\(authorHandle) commented on your post"
+                        NotificationService.shared.createNotification(
+                            to: livePost.authorID,
+                            type: .comment,
+                            actorID: user.uid,
+                            message: message,
+                            postID: postID
+                        )
                     }
                 } catch {
                     print("Error posting comment: \(error)")
@@ -518,6 +543,30 @@ struct PostDetailView: View {
                 }
             }
         }
+    }
+
+    private func toggleCommentLike(_ comment: Comment) {
+        guard let postID = livePost.id ?? post.id,
+              let commentID = comment.id else { return }
+        CommentService.shared.toggleLike(
+            postID: postID,
+            commentID: commentID,
+            parentCommentID: comment.parentCommentID
+        ) { result in
+            if case .failure(let error) = result {
+                print("Failed to like comment: \(error)")
+            }
+        }
+    }
+
+    private func commentIsLiked(_ comment: Comment) -> Bool {
+        guard let uid = auth.currentUser?.uid else { return false }
+        return comment.resolvedLikedBy.contains(uid)
+    }
+
+    private func commentLikeLabel(for comment: Comment) -> String {
+        let count = comment.resolvedLikeCount
+        return count > 0 ? "\(count)" : "Like"
     }
 
     private func checkSaveState() {

--- a/yummr/PostService.swift
+++ b/yummr/PostService.swift
@@ -14,7 +14,13 @@ class PostService: ObservableObject {
     @Published var cachedTopPosts: [Post] = []
 
     func toggleLike(for post: Post, completion: @escaping (Result<Void, Error>) -> Void) {
-        guard let uid = Auth.auth().currentUser?.uid else { return }
+        guard let uid = Auth.auth().currentUser?.uid else {
+            completion(.failure(
+                NSError(domain: "AuthError", code: 0,
+                        userInfo: [NSLocalizedDescriptionKey: "User not logged in."])
+            ))
+            return
+        }
         guard let postID = post.id else {
             completion(.failure(
                 NSError(domain: "PostError", code: 0,
@@ -35,8 +41,9 @@ class PostService: ObservableObject {
 
             var likedBy = postDoc.data()?["likedBy"] as? [String] ?? []
             var likeCount = postDoc.data()?["likeCount"] as? Int ?? 0
+            let wasLiked = likedBy.contains(uid)
 
-            if likedBy.contains(uid) {
+            if wasLiked {
                 likedBy.removeAll { $0 == uid }
                 likeCount = max(0, likeCount - 1)
             } else {
@@ -49,12 +56,27 @@ class PostService: ObservableObject {
                 "likeCount": likeCount
             ], forDocument: postRef)
 
-            return nil
-        }) { _, error in
+            return wasLiked
+        }) { result, error in
             if let error = error {
                 completion(.failure(error))
             } else {
                 completion(.success(()))
+                let wasLiked = result as? Bool ?? true
+                if !wasLiked, post.authorID != uid {
+                    UserService.shared.fetchUser(withID: uid) { user in
+                        let actorName = HandleFormatter.normalizedHandleIfPresent(user?.handle)
+                            ?? HandleFormatter.normalizedHandle(from: user?.displayName ?? "Someone")
+                        let message = "\(actorName) liked your post"
+                        NotificationService.shared.createNotification(
+                            to: post.authorID,
+                            type: .like,
+                            actorID: uid,
+                            message: message,
+                            postID: post.id
+                        )
+                    }
+                }
             }
         }
     }

--- a/yummr/RootView.swift
+++ b/yummr/RootView.swift
@@ -15,46 +15,28 @@ struct RootView: View {
 
     @StateObject var auth = AuthService()
     @State private var selectedTab: Tab = .feed
-    @State private var feedViewID = UUID()
-    @State private var searchViewID = UUID()
-    @State private var createViewID = UUID()
-    @State private var savedViewID = UUID()
-    @State private var profileViewID = UUID()
 
     var body: some View {
         Group {
             if auth.currentUser != nil {
-                TabView(selection: Binding(
-                    get: { selectedTab },
-                    set: { newValue in
-                        if selectedTab == newValue {
-                            resetView(for: newValue)
-                        }
-                        selectedTab = newValue
-                    }
-                )) {
+                TabView(selection: $selectedTab) {
                     FeedView()
-                        .id(feedViewID)
                         .tabItem { Label("Feed",    systemImage: "list.bullet") }
                         .tag(Tab.feed)
 
                     SearchView()
-                        .id(searchViewID)
                         .tabItem { Label("Search",  systemImage: "magnifyingglass") }
                         .tag(Tab.search)
 
                     CreatePostView()
-                        .id(createViewID)
                         .tabItem { Label("Create",  systemImage: "plus.circle") }
                         .tag(Tab.create)
 
                     SavedCollectionsView()
-                        .id(savedViewID)
                         .tabItem { Label("Saved", systemImage: "bookmark") }
                         .tag(Tab.saved)
 
                     ProfileView()
-                        .id(profileViewID)
                         .tabItem { Label("Profile", systemImage: "person.crop.circle") }
                         .tag(Tab.profile)
                 }
@@ -63,20 +45,5 @@ struct RootView: View {
             }
         }
         .environmentObject(auth)
-    }
-
-    private func resetView(for tab: Tab) {
-        switch tab {
-        case .feed:
-            feedViewID = UUID()
-        case .search:
-            searchViewID = UUID()
-        case .create:
-            createViewID = UUID()
-        case .saved:
-            savedViewID = UUID()
-        case .profile:
-            profileViewID = UUID()
-        }
     }
 }

--- a/yummr/UserService.swift
+++ b/yummr/UserService.swift
@@ -208,7 +208,13 @@ final class UserService: ObservableObject {
                 .whereField(FieldPath.documentID(), in: chunk)
                 .getDocuments { snapshot, _ in
                     if let documents = snapshot?.documents {
-                        let users = documents.compactMap { try? $0.data(as: AppUser.self) }
+                        let users = documents.compactMap { document in
+                            guard var user = try? document.data(as: AppUser.self) else { return nil }
+                            if user.id == nil {
+                                user.id = document.documentID
+                            }
+                            return user
+                        }
                         fetched.append(contentsOf: users)
                     }
                     group.leave()
@@ -362,7 +368,13 @@ final class UserService: ObservableObject {
             .whereField("privacySettings.allowContactDiscovery", isEqualTo: true)
             .limit(to: limit)
             .getDocuments { snapshot, _ in
-                let users = snapshot?.documents.compactMap { try? $0.data(as: AppUser.self) } ?? []
+                let users = snapshot?.documents.compactMap { document in
+                    guard var user = try? document.data(as: AppUser.self) else { return nil }
+                    if user.id == nil {
+                        user.id = document.documentID
+                    }
+                    return user
+                } ?? []
                 let filtered = users.filter { $0.id != uid }
                 completion(filtered)
             }

--- a/yummr/UserService.swift
+++ b/yummr/UserService.swift
@@ -161,7 +161,13 @@ final class UserService: ObservableObject {
 
      
                 let lowercasedQuery = normalizedQuery.lowercased()
-                let users: [AppUser] = documents.compactMap { try? $0.data(as: AppUser.self) }
+                let users: [AppUser] = documents.compactMap { document in
+                    guard var user = try? document.data(as: AppUser.self) else { return nil }
+                    if user.id == nil {
+                        user.id = document.documentID
+                    }
+                    return user
+                }
                     .sorted { ($0.displayName.lowercased(), $0.handle.lowercased()) < ($1.displayName.lowercased(), $1.handle.lowercased()) }
                     .filter { user in
                         let handle = user.handle.lowercased()


### PR DESCRIPTION
### Motivation
- Present calorie estimates using the full word for clarity in the UI and match requested wording.

### Description
- Changed the formatted calorie output in `Post` metadata to return `"\(calories) calories"` instead of `"\(calories) kcal"`.
- Modified file: `yummr/Post+Metadata.swift` (updated `formattedCalories`).

### Testing
- No automated tests were run for this change.
- Manual verification is recommended to confirm the updated label appears where `formattedCalories` is shown.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696083b261d88323a3cbc81452e6b369)