### PR TITLE
Preserve AI notes (no comma-split) and polish UX, prefetching, navigation, and follow/save logic

### DIFF
--- a/yummr/AutoLogFlowView.swift
+++ b/yummr/AutoLogFlowView.swift
@@ -29,6 +29,8 @@ struct AutoLogSheetView: View {
     @State private var youtubeErrorMessage: String?
     @State private var draftState: AutoLogDraftState?
     @State private var showDraftReview = false
+    @FocusState private var isTranscriptFocused: Bool
+    @FocusState private var isYouTubeFocused: Bool
 
     var body: some View {
         NavigationStack {
@@ -47,7 +49,9 @@ struct AutoLogSheetView: View {
                     referencePhotosSection
 
                     Button {
-                        requestAIDraft()
+                        performButtonAction {
+                            requestAIDraft()
+                        }
                     } label: {
                         Label(isDrafting ? "Drafting..." : "Draft with AI", systemImage: "wand.and.stars")
                             .frame(maxWidth: .infinity)
@@ -63,10 +67,7 @@ struct AutoLogSheetView: View {
                 }
                 .padding()
             }
-            .contentShape(Rectangle())
-            .onTapGesture {
-                dismissKeyboard()
-            }
+            .scrollDismissesKeyboard(.interactively)
             .navigationTitle("Auto Log")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -158,6 +159,7 @@ struct AutoLogSheetView: View {
                     RoundedRectangle(cornerRadius: 12)
                         .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                 )
+                .focused($isTranscriptFocused)
         }
         .padding()
         .background(Color(UIColor.secondarySystemBackground))
@@ -181,9 +183,15 @@ struct AutoLogSheetView: View {
                 ) {
                     Label("Add Photos", systemImage: "photo.on.rectangle")
                 }
+                .simultaneousGesture(TapGesture().onEnded {
+                    isTranscriptFocused = false
+                    isYouTubeFocused = false
+                })
 
                 Button {
-                    showReferenceCamera = true
+                    performButtonAction {
+                        showReferenceCamera = true
+                    }
                 } label: {
                     Label("Capture", systemImage: "camera")
                 }
@@ -241,9 +249,12 @@ struct AutoLogSheetView: View {
                 .textFieldStyle(.roundedBorder)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
+                .focused($isYouTubeFocused)
 
             Button {
-                fetchYouTubeTranscript()
+                performButtonAction {
+                    fetchYouTubeTranscript()
+                }
             } label: {
                 HStack {
                     if isFetchingYouTube {
@@ -278,6 +289,14 @@ struct AutoLogSheetView: View {
         .padding()
         .background(Color(UIColor.secondarySystemBackground))
         .cornerRadius(12)
+    }
+
+    private func performButtonAction(_ action: @escaping () -> Void) {
+        isTranscriptFocused = false
+        isYouTubeFocused = false
+        DispatchQueue.main.async {
+            action()
+        }
     }
 
     private func requestAIDraft() {
@@ -574,8 +593,8 @@ struct AutoLogDraftReviewView: View {
                     }
 
                     Button("Confirm Draft") {
-                        let ingredients = splitLines(from: ingredientsText)
-                        let notes = splitLines(from: notesText)
+                        let ingredients = splitLines(from: ingredientsText, allowCommas: true)
+                        let notes = splitLines(from: notesText, allowCommas: false)
                         let confirmed = AutoLogDraftState(
                             title: stripCreativeTags(title),
                             description: stripCreativeTags(description),
@@ -602,9 +621,12 @@ struct AutoLogDraftReviewView: View {
         }
     }
 
-    private func splitLines(from text: String) -> [String] {
-        text
-            .components(separatedBy: CharacterSet.newlines.union([","]))
+    private func splitLines(from text: String, allowCommas: Bool) -> [String] {
+        let separators = allowCommas
+            ? CharacterSet.newlines.union([","])
+            : CharacterSet.newlines
+        return text
+            .components(separatedBy: separators)
             .map { stripCreativeTags($0).trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
     }

--- a/yummr/CachedWebImage.swift
+++ b/yummr/CachedWebImage.swift
@@ -12,6 +12,31 @@ final class ImageCache {
     func store(image: UIImage, for url: URL) {
         cache.setObject(image, forKey: url.absoluteString as NSString)
     }
+
+    func prefetch(urls: [URL], completion: (() -> Void)? = nil) {
+        guard !urls.isEmpty else {
+            completion?()
+            return
+        }
+
+        let group = DispatchGroup()
+
+        for url in urls {
+            if image(for: url) != nil {
+                continue
+            }
+            group.enter()
+            URLSession.shared.dataTask(with: url) { data, _, _ in
+                defer { group.leave() }
+                guard let data = data, let image = UIImage(data: data) else { return }
+                self.store(image: image, for: url)
+            }.resume()
+        }
+
+        group.notify(queue: .main) {
+            completion?()
+        }
+    }
 }
 
 struct CachedWebImage<Placeholder: View>: View {

--- a/yummr/CreatePostView.swift
+++ b/yummr/CreatePostView.swift
@@ -38,6 +38,15 @@ struct CreatePostView: View {
     @State private var youtubeTranscript: String = ""
     @State private var youtubeTitle: String = ""
     @State private var aiNotes: [String] = []
+    @FocusState private var focusedField: Field?
+
+    private enum Field: Hashable {
+        case title
+        case description
+        case cookTime
+        case calorieEstimate
+        case ingredient
+    }
 
     var body: some View {
         NavigationView {
@@ -46,14 +55,17 @@ struct CreatePostView: View {
                     Group {
                         TextField("Title", text: $title)
                             .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .focused($focusedField, equals: .title)
 
                         TextField("Description", text: $description, axis: .vertical)
                             .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .focused($focusedField, equals: .description)
 
                         photoActionButtons
 
                         TextField("Cook time (e.g. 45 minutes)", text: $cookTime)
                             .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .focused($focusedField, equals: .cookTime)
                     }
 
                     ingredientsSection
@@ -61,6 +73,7 @@ struct CreatePostView: View {
                     TextField("Calories (estimated)", text: $calorieEstimate)
                         .keyboardType(.numberPad)
                         .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .focused($focusedField, equals: .calorieEstimate)
 
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Recipe Instructions")
@@ -81,7 +94,9 @@ struct CreatePostView: View {
                     }
 
                     Button {
-                        showAutoLogSheet = true
+                        performButtonAction {
+                            showAutoLogSheet = true
+                        }
                     } label: {
                         Label("Auto Log with AI", systemImage: "wand.and.stars")
                             .font(.headline)
@@ -135,11 +150,8 @@ struct CreatePostView: View {
                 }
                 .padding()
             }
+            .scrollDismissesKeyboard(.interactively)
             .navigationTitle("Create Post")
-        }
-        .contentShape(Rectangle())
-        .onTapGesture {
-            dismissKeyboard()
         }
         .sheet(isPresented: $showCameraPicker) {
             ImagePicker(image: $capturedImage, sourceType: .camera)
@@ -249,6 +261,7 @@ struct CreatePostView: View {
             HStack {
                 TextField("Add ingredient or keyword", text: $ingredientDraft)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .focused($focusedField, equals: .ingredient)
                 Button("Add") {
                     addIngredient()
                 }
@@ -298,12 +311,17 @@ struct CreatePostView: View {
                     .cornerRadius(16)
                 }
                 .buttonStyle(.plain)
+                .simultaneousGesture(TapGesture().onEnded {
+                    focusedField = nil
+                })
 
                 Button {
-                    if UIImagePickerController.isSourceTypeAvailable(.camera) {
-                        showCameraPicker = true
-                    } else {
-                        cameraUnavailableAlert = true
+                    performButtonAction {
+                        if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                            showCameraPicker = true
+                        } else {
+                            cameraUnavailableAlert = true
+                        }
                     }
                 } label: {
                     VStack(spacing: 8) {
@@ -346,6 +364,13 @@ struct CreatePostView: View {
                     .padding(.vertical, 4)
                 }
             }
+        }
+    }
+
+    private func performButtonAction(_ action: @escaping () -> Void) {
+        focusedField = nil
+        DispatchQueue.main.async {
+            action()
         }
     }
 

--- a/yummr/FeedView.swift
+++ b/yummr/FeedView.swift
@@ -16,33 +16,39 @@ struct FeedView: View {
     @State private var friendsListener: ListenerRegistration?
     @State private var showNotifications = false
     @State private var isRefreshing = false
+    @State private var selectedPost: Post?
+    @State private var isShowingPostDetail = false
 
     private let db = Firestore.firestore()
 
     var body: some View {
         NavigationView {
             ScrollView {
-                if posts.isEmpty {
-                    VStack(spacing: 12) {
-                        Text("No posts yet.")
-                            .font(.headline)
-                        Text("Add friends or share your first post to get started.")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                            .multilineTextAlignment(.center)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.top, 80)
-                } else {
-                    VStack(spacing: 8) {
-                        ForEach(posts) { post in
-                            NavigationLink(destination: PostDetailView(post: post)) {
-                                PostCard(post: post)
-                            }
-                            .buttonStyle(.plain)
+                ZStack {
+                    if posts.isEmpty {
+                        VStack(spacing: 12) {
+                            Text("No posts yet.")
+                                .font(.headline)
+                            Text("Add friends or share your first post to get started.")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.center)
                         }
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 80)
+                    } else {
+                        VStack(spacing: 8) {
+                            ForEach(posts) { post in
+                                PostCard(post: post) {
+                                    openPostDetail(post)
+                                }
+                            }
+                        }
+                        .padding(.vertical, 8)
                     }
-                    .padding(.vertical, 8)
+
+                    postDetailLink
+                        .hidden()
                 }
             }
             .navigationTitle("The Feed")
@@ -119,5 +125,30 @@ struct FeedView: View {
             .filter { allowedAuthorIDs.contains($0.authorID) }
             .sorted { $0.timestamp > $1.timestamp }
         posts = filtered
+    }
+
+    private func openPostDetail(_ post: Post) {
+        selectedPost = post
+        isShowingPostDetail = true
+    }
+
+    @ViewBuilder
+    private var postDetailLink: some View {
+        if let selectedPost {
+            NavigationLink(
+                destination: PostDetailView(post: selectedPost),
+                isActive: Binding(
+                    get: { isShowingPostDetail },
+                    set: { newValue in
+                        if !newValue {
+                            selectedPost = nil
+                        }
+                        isShowingPostDetail = newValue
+                    }
+                )
+            ) {
+                EmptyView()
+            }
+        }
     }
 }

--- a/yummr/FriendService.swift
+++ b/yummr/FriendService.swift
@@ -99,7 +99,7 @@ final class FriendService: ObservableObject {
 
         batch.commit { error in
             if error == nil {
-                self.incrementFriendCounts(for: [currentUID, requesterUID], delta: 1)
+                self.updateFollowCounts(followerUID: requesterUID, followingUID: currentUID, delta: 1)
             }
             completion?(error)
         }
@@ -120,7 +120,7 @@ final class FriendService: ObservableObject {
         batch.deleteDocument(otherRef)
         batch.commit { error in
             if error == nil {
-                self.incrementFriendCounts(for: [currentUID, friendUID], delta: -1)
+                self.updateFollowCounts(followerUID: currentUID, followingUID: friendUID, delta: -1)
             }
             completion?(error)
         }
@@ -152,7 +152,7 @@ final class FriendService: ObservableObject {
 
         batch.commit { error in
             if error == nil {
-                self.incrementFriendCounts(for: [currentUID, targetUID], delta: 1)
+                self.updateFollowCounts(followerUID: currentUID, followingUID: targetUID, delta: 1)
                 UserService.shared.fetchUser(withID: currentUID) { user in
                     let actorName = HandleFormatter.normalizedHandleIfPresent(user?.handle)
                         ?? HandleFormatter.normalizedHandle(from: user?.displayName ?? "Someone")
@@ -199,16 +199,17 @@ final class FriendService: ObservableObject {
             }
     }
 
-    private func incrementFriendCounts(for uids: [String], delta: Int64) {
+    private func updateFollowCounts(followerUID: String, followingUID: String, delta: Int64) {
         guard delta != 0 else { return }
         let batch = db.batch()
-        uids.forEach { uid in
-            let userRef = db.collection("users").document(uid)
-            batch.setData([
-                "followerCount": FieldValue.increment(delta),
-                "followingCount": FieldValue.increment(delta)
-            ], forDocument: userRef, merge: true)
-        }
+        let followerRef = db.collection("users").document(followerUID)
+        let followingRef = db.collection("users").document(followingUID)
+        batch.setData([
+            "followingCount": FieldValue.increment(delta)
+        ], forDocument: followerRef, merge: true)
+        batch.setData([
+            "followerCount": FieldValue.increment(delta)
+        ], forDocument: followingRef, merge: true)
         batch.commit(completion: nil)
     }
 }

--- a/yummr/PostCard.swift
+++ b/yummr/PostCard.swift
@@ -5,6 +5,7 @@ import UIKit
 
 struct PostCard: View {
     var post: Post
+    var onOpenDetails: (() -> Void)?
     @State private var likeCount: Int
     @State private var isLiked: Bool
     @State private var isProcessingLike = false
@@ -18,8 +19,9 @@ struct PostCard: View {
     @State private var isShareSheetPresented = false
     @State private var shareItems: [Any] = []
 
-    init(post: Post) {
+    init(post: Post, onOpenDetails: (() -> Void)? = nil) {
         self.post = post
+        self.onOpenDetails = onOpenDetails
         _likeCount = State(initialValue: post.likeCount)
         _isLiked = State(initialValue: post.likedBy.contains(Auth.auth().currentUser?.uid ?? ""))
     }
@@ -30,7 +32,7 @@ struct PostCard: View {
 
             titleRow
 
-            imageCarousel
+            detailTapArea
 
             if !post.photoTags.isEmpty {
                 Button {
@@ -181,6 +183,8 @@ struct PostCard: View {
                 .labelStyle(.titleAndIcon)
                 .appTextStyle(.footnote, weight: .medium)
                 .foregroundColor(tint)
+                .padding(.vertical, 6)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }
@@ -223,10 +227,16 @@ struct PostCard: View {
     }
 
     private func toggleSave() {
+        let previous = isSaved
+        isSaved.toggle()
         SavedService.shared.toggleSave(post: post) { result in
             DispatchQueue.main.async {
-                if case .success(let saved) = result {
+                switch result {
+                case .success(let saved):
                     self.isSaved = saved
+                case .failure(let error):
+                    print("Failed to save post: \(error)")
+                    self.isSaved = previous
                 }
             }
         }
@@ -273,6 +283,18 @@ struct PostCard: View {
             }
         }
         .frame(height: UIScreen.main.bounds.width * 0.95)
+    }
+
+    @ViewBuilder
+    private var detailTapArea: some View {
+        if let onOpenDetails {
+            Button(action: onOpenDetails) {
+                imageCarousel
+            }
+            .buttonStyle(.plain)
+        } else {
+            imageCarousel
+        }
     }
 
     private func tagOverlay(tag: Post.PhotoTag, size: CGSize) -> some View {
@@ -460,15 +482,20 @@ struct PostCard: View {
     private func toggleLike() {
         guard !isProcessingLike else { return }
         isProcessingLike = true
+        let previousLiked = isLiked
+        let previousCount = likeCount
+        isLiked.toggle()
+        likeCount += isLiked ? 1 : -1
 
         PostService.shared.toggleLike(for: post) { result in
             DispatchQueue.main.async {
                 switch result {
                 case .success():
-                    isLiked.toggle()
-                    likeCount += isLiked ? 1 : -1
+                    break
                 case .failure(let error):
                     print("Failed to like post: \(error)")
+                    isLiked = previousLiked
+                    likeCount = previousCount
                 }
                 isProcessingLike = false
             }

--- a/yummr/PostDetailView.swift
+++ b/yummr/PostDetailView.swift
@@ -544,10 +544,16 @@ struct PostDetailView: View {
     }
 
     private func toggleSave() {
+        let previous = isSaved
+        isSaved.toggle()
         SavedService.shared.toggleSave(post: livePost) { result in
             DispatchQueue.main.async {
-                if case .success(let saved) = result {
+                switch result {
+                case .success(let saved):
                     self.isSaved = saved
+                case .failure(let error):
+                    print("Failed to save post: \(error)")
+                    self.isSaved = previous
                 }
             }
         }

--- a/yummr/PostService.swift
+++ b/yummr/PostService.swift
@@ -268,6 +268,27 @@ class PostService: ObservableObject {
             }
     }
 
+    func preloadTopPostsAndImages(limit: Int = 8, completion: (() -> Void)? = nil) {
+        db.collection("posts")
+            .order(by: "timestamp", descending: true)
+            .limit(to: limit)
+            .getDocuments { snapshot, _ in
+                let posts = snapshot?.documents.compactMap { try? $0.data(as: Post.self) } ?? []
+                DispatchQueue.main.async {
+                    self.cachedTopPosts = posts
+                }
+
+                let urls = posts.compactMap { post -> URL? in
+                    guard let first = post.imageURLs.first else { return nil }
+                    return URL(string: first)
+                }
+
+                ImageCache.shared.prefetch(urls: urls) {
+                    completion?()
+                }
+            }
+    }
+
     func updatePost(postID: String,
                     title: String? = nil,
                     description: String,

--- a/yummr/ProfileView.swift
+++ b/yummr/ProfileView.swift
@@ -31,7 +31,6 @@ struct ProfileView: View {
     @State private var showSettings = false
     @State private var followerCount: Int = 0
     @State private var followingCount: Int = 0
-    @State private var hasFriendCounts = false
     @State private var activeFriendList: FriendListView.Mode?
     @State private var isFollowingProfile = false
     @State private var isProcessingFollowAction = false
@@ -39,7 +38,6 @@ struct ProfileView: View {
     @State private var isShowingUserFeed = false
 
     private let db = Firestore.firestore()
-    @State private var friendListener: ListenerRegistration?
     @State private var profileListener: ListenerRegistration?
 
     private var resolvedUserID: String? {
@@ -127,7 +125,6 @@ struct ProfileView: View {
             loadProfileData()
             loadPosts()
             loadTaggedPosts()
-            startFriendListener()
             refreshFriendshipState()
         }
         .onDisappear(perform: stopListeners)
@@ -440,7 +437,6 @@ struct ProfileView: View {
 
     private func loadProfileData() {
         guard let uid = resolvedUserID else { return }
-        hasFriendCounts = false
         profileListener?.remove()
         profileListener = db.collection("users").document(uid)
             .addSnapshotListener { snapshot, _ in
@@ -448,10 +444,8 @@ struct ProfileView: View {
                     DispatchQueue.main.async {
                         self.profileUser = user
                         self.bio = user.bio ?? ""
-                        if !hasFriendCounts {
-                            self.followerCount = user.followerCount ?? 0
-                            self.followingCount = user.followingCount ?? 0
-                        }
+                        self.followerCount = user.followerCount ?? 0
+                        self.followingCount = user.followingCount ?? 0
                         if let profileURL = user.profileImageURL, let url = URL(string: profileURL) {
                             self.profileImageURL = url
                         }
@@ -543,21 +537,7 @@ struct ProfileView: View {
         }
     }
 
-    private func startFriendListener() {
-        guard let uid = resolvedUserID else { return }
-        friendListener?.remove()
-        friendListener = FriendService.shared.observeFriendIDs(for: uid) { ids in
-            DispatchQueue.main.async {
-                self.followerCount = ids.count
-                self.followingCount = ids.count
-                self.hasFriendCounts = true
-            }
-        }
-    }
-
     private func stopListeners() {
-        friendListener?.remove()
-        friendListener = nil
         profileListener?.remove()
         profileListener = nil
     }

--- a/yummr/UserPostsFeedView.swift
+++ b/yummr/UserPostsFeedView.swift
@@ -12,6 +12,8 @@ struct UserPostsFeedView: View {
     @State private var isLoading = true
     @State private var listener: ListenerRegistration?
     @State private var hasScrolledToInitialPost = false
+    @State private var selectedPost: Post?
+    @State private var isShowingPostDetail = false
 
     private let db = Firestore.firestore()
 
@@ -29,15 +31,17 @@ struct UserPostsFeedView: View {
                     LazyVStack(spacing: 24) {
                         ForEach(posts) { post in
                             let identifier = post.stableIdentifier
-                            NavigationLink(destination: PostDetailView(post: post)) {
-                                PostCard(post: post)
+                            PostCard(post: post) {
+                                openPostDetail(post)
                             }
-                            .buttonStyle(.plain)
                             .id(identifier)
                         }
                     }
                     .padding()
                 }
+
+                postDetailLink
+                    .hidden()
             }
         .onChange(of: posts.map { $0.stableIdentifier }) { _ in
             guard !hasScrolledToInitialPost,
@@ -99,5 +103,30 @@ struct UserPostsFeedView: View {
                     self.isLoading = false
                 }
             }
+    }
+
+    private func openPostDetail(_ post: Post) {
+        selectedPost = post
+        isShowingPostDetail = true
+    }
+
+    @ViewBuilder
+    private var postDetailLink: some View {
+        if let selectedPost {
+            NavigationLink(
+                destination: PostDetailView(post: selectedPost),
+                isActive: Binding(
+                    get: { isShowingPostDetail },
+                    set: { newValue in
+                        if !newValue {
+                            selectedPost = nil
+                        }
+                        isShowingPostDetail = newValue
+                    }
+                )
+            ) {
+                EmptyView()
+            }
+        }
     }
 }

--- a/yummr/yummrApp.swift
+++ b/yummr/yummrApp.swift
@@ -61,12 +61,27 @@ private struct AppRootView: View {
             }
         }
         .onAppear {
-            PostService.shared.preloadTopPosts(limit: 5) {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            let start = Date()
+            let minDuration: TimeInterval = 1.0
+            let maxDuration: TimeInterval = 3.0
+            var didFinish = false
+
+            func finishSplash(after delay: TimeInterval) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                    guard !didFinish else { return }
+                    didFinish = true
                     withAnimation(.easeInOut(duration: 0.6)) {
                         showSplash = false
                     }
                 }
+            }
+
+            finishSplash(after: maxDuration)
+
+            PostService.shared.preloadTopPostsAndImages(limit: 8) {
+                let elapsed = Date().timeIntervalSince(start)
+                let remaining = max(0, minDuration - elapsed)
+                finishSplash(after: remaining)
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Prevent AI-generated notes from being incorrectly split into multiple bullet items by avoiding comma-based splitting for notes.
- Improve keyboard and focus behavior in the auto-log and create-post flows so taps on photo pickers and buttons reliably dismiss text input.
- Improve perceived startup and feed performance by preloading top posts and warming the image cache while keeping splash screen duration bounded.
- Make follow counts, save and like updates, and in-app navigation more robust and user-friendly with safer optimistic updates and programmatic navigation.

### Description
- Update `AutoLogFlowView` to add `splitLines(from:allowCommas:)`, use `allowCommas: false` for notes and `true` for ingredients, add focus states (`isTranscriptFocused`, `isYouTubeFocused`), and introduce `performButtonAction` to clear focus before actions and enable `.scrollDismissesKeyboard(.interactively)`.
- Add `@FocusState` tooling and `performButtonAction` to `CreatePostView` to clear focused fields when launching camera/gallery/auto-log and enable interactive keyboard dismissal.
- Add `ImageCache.prefetch(urls:completion:)` in `CachedWebImage.swift` and `PostService.preloadTopPostsAndImages(limit:completion:)` to warm both post data and their first images.
- Change `AppRootView` (`yummrApp.swift`) to enforce a minimum and maximum splash duration and to call `preloadTopPostsAndImages` so the splash does not block indefinitely while prefetching.
- Replace implicit `NavigationLink` usage with a programmatic detail-opening flow: add `onOpenDetails` closure to `PostCard`, manage `selectedPost` and hidden `NavigationLink` in `FeedView` and `UserPostsFeedView` to allow tapping image area to open details.
- Refactor friend-count update logic in `FriendService` by replacing `incrementFriendCounts` with `updateFollowCounts` that updates follower and following counts separately and adjust `ProfileView` to read counts from profile snapshots.
- Harden save/like actions in `PostCard` and `PostDetailView` by applying optimistic UI updates and rolling back state on failure, and improve save/like error logging and state handling.

### Testing
- No automated tests were executed for these changes.
- Changes were committed and packaged for review but no CI/test run was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fd941ce5483238f4e3ace455289c8)